### PR TITLE
Improve MCP tool descriptions with safety labels and API context

### DIFF
--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -4,7 +4,7 @@ import { getConfig, formatResponse } from "../api/client.js";
 export function registerAdminTools(server: McpServer) {
   server.tool(
     "get_admins",
-    "Get all administrator accounts configured on the firewall",
+    "[READ-ONLY] Retrieves all administrator accounts configured on the firewall. Reads config at: /config/mgt-config/users.",
     {},
     async () => {
       const result = await getConfig("/config/mgt-config/users");
@@ -14,7 +14,7 @@ export function registerAdminTools(server: McpServer) {
 
   server.tool(
     "get_admin_roles",
-    "Get administrator role definitions and their permissions",
+    "[READ-ONLY] Retrieves administrator role definitions and their permissions. Reads config at: /config/.../vsys/entry/admin-role.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/admin-role");
@@ -24,7 +24,7 @@ export function registerAdminTools(server: McpServer) {
 
   server.tool(
     "get_auth_profiles",
-    "Get authentication profiles including RADIUS, LDAP, TACACS+ configurations",
+    "[READ-ONLY] Retrieves authentication profiles including RADIUS, LDAP, and TACACS+ configurations. Reads config at: /config/shared/authentication-profile.",
     {},
     async () => {
       const result = await getConfig("/config/shared/authentication-profile");

--- a/src/tools/certificates.ts
+++ b/src/tools/certificates.ts
@@ -4,7 +4,7 @@ import { getConfig, formatResponse } from "../api/client.js";
 export function registerCertificatesTools(server: McpServer) {
   server.tool(
     "get_certificates",
-    "Get SSL/TLS certificates configured on the firewall",
+    "[READ-ONLY] Retrieves SSL/TLS certificates configured on the firewall. Reads config at: /config/shared/certificate.",
     {},
     async () => {
       const result = await getConfig("/config/shared/certificate");
@@ -14,7 +14,7 @@ export function registerCertificatesTools(server: McpServer) {
 
   server.tool(
     "get_decryption_rules",
-    "Get SSL decryption policy rules",
+    "[READ-ONLY] Retrieves SSL decryption policy rules. Reads config at: /config/.../rulebase/decryption/rules.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/decryption/rules");
@@ -24,7 +24,7 @@ export function registerCertificatesTools(server: McpServer) {
 
   server.tool(
     "get_decryption_profiles",
-    "Get SSL decryption profiles",
+    "[READ-ONLY] Retrieves SSL decryption profiles. Reads config at: /config/.../profiles/decryption.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/profiles/decryption");

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -5,7 +5,7 @@ import { setConfig, deleteConfig, commitConfig, commitAll, formatResponse } from
 export function registerConfigTools(server: McpServer) {
   server.tool(
     "set_config",
-    "Set configuration at a specific XPath location (creates or updates). Changes are staged until committed.",
+    "[MODIFIES CONFIG] Sets or creates configuration at a specific XPath location on the firewall. Changes are staged in the candidate config and require a separate 'commit' to take effect on the running firewall.",
     {
       xpath: z.string().describe("XPath to the configuration location (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address')"),
       element: z.string().describe("XML element to set at the xpath location (e.g., '<entry name=\"test-addr\"><ip-netmask>10.0.0.1/32</ip-netmask></entry>')"),
@@ -18,7 +18,7 @@ export function registerConfigTools(server: McpServer) {
 
   server.tool(
     "delete_config",
-    "Delete configuration at a specific XPath location. Changes are staged until committed.",
+    "[MODIFIES CONFIG] Deletes configuration at a specific XPath location on the firewall. Changes are staged in the candidate config and require a separate 'commit' to take effect.",
     {
       xpath: z.string().describe("XPath to the configuration element to delete (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address/entry[@name=\"test-addr\"]')"),
     },
@@ -30,7 +30,7 @@ export function registerConfigTools(server: McpServer) {
 
   server.tool(
     "commit",
-    "Commit pending configuration changes to the firewall",
+    "[MODIFIES CONFIG] Commits all pending (staged) configuration changes to the running firewall. This activates changes made by set_config/delete_config. This action affects live traffic.",
     {
       description: z.string().optional().describe("Optional commit description/comment"),
       partial_admin: z.string().optional().describe("Commit only changes made by this admin user"),
@@ -51,7 +51,7 @@ export function registerConfigTools(server: McpServer) {
 
   server.tool(
     "panorama_push_to_devices",
-    "Push configuration from Panorama to managed devices (Panorama only)",
+    "[MODIFIES CONFIG] Pushes configuration from Panorama to managed firewall devices. This deploys policy and object changes to production firewalls in the specified device group. This action affects live traffic on managed devices.",
     {
       device_group: z.string().describe("Device group name to push to"),
       description: z.string().optional().describe("Optional push description"),

--- a/src/tools/licenses.ts
+++ b/src/tools/licenses.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, formatResponse } from "../api/client.js";
 export function registerLicensesTools(server: McpServer) {
   server.tool(
     "get_licenses",
-    "Get license status and expiration dates for all features",
+    "[READ-ONLY] Retrieves license status and expiration dates for all features. Executes: request license info.",
     {},
     async () => {
       const result = await executeOpCommand("<request><license><info></info></license></request>");
@@ -14,7 +14,7 @@ export function registerLicensesTools(server: McpServer) {
 
   server.tool(
     "get_license_usage",
-    "Get license usage information including GlobalProtect users and other licensed features",
+    "[READ-ONLY] Retrieves license usage information including VM model, serial, capacity tier, and mode. Executes: show system info (extracts license fields).",
     {},
     async () => {
       const result = await executeOpCommand("<show><system><info></info></system></show>");

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -5,7 +5,7 @@ import { executeOpCommand, formatResponse } from "../api/client.js";
 export function registerLogsTools(server: McpServer) {
   server.tool(
     "get_traffic_logs",
-    "Get recent traffic logs from the firewall",
+    "[READ-ONLY] Retrieves recent traffic logs from the firewall. Executes: show log traffic. Supports filtering by query and limiting result count.",
     {
       nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
       query: z.string().optional().describe("Filter query (e.g., '( addr.src in 10.0.0.0/8 )')"),
@@ -24,7 +24,7 @@ export function registerLogsTools(server: McpServer) {
 
   server.tool(
     "get_threat_logs",
-    "Get recent threat logs from the firewall",
+    "[READ-ONLY] Retrieves recent threat logs from the firewall. Executes: show log threat. Supports filtering by query and limiting result count.",
     {
       nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
       query: z.string().optional().describe("Filter query (e.g., '( severity eq critical )')"),
@@ -43,7 +43,7 @@ export function registerLogsTools(server: McpServer) {
 
   server.tool(
     "get_system_logs",
-    "Get recent system logs from the firewall",
+    "[READ-ONLY] Retrieves recent system logs from the firewall. Executes: show log system. Supports filtering by query and limiting result count.",
     {
       nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
       query: z.string().optional().describe("Filter query (e.g., '( severity eq critical )')"),
@@ -62,7 +62,7 @@ export function registerLogsTools(server: McpServer) {
 
   server.tool(
     "get_config_logs",
-    "Get recent configuration change logs from the firewall",
+    "[READ-ONLY] Retrieves recent configuration change logs from the firewall. Executes: show log config. Supports filtering by query and limiting result count.",
     {
       nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
       query: z.string().optional().describe("Filter query"),

--- a/src/tools/nat.ts
+++ b/src/tools/nat.ts
@@ -4,7 +4,7 @@ import { getConfig, formatResponse } from "../api/client.js";
 export function registerNatTools(server: McpServer) {
   server.tool(
     "get_nat_rules",
-    "Get all NAT policy rules including source NAT, destination NAT, and bidirectional rules",
+    "[READ-ONLY] Retrieves all NAT policy rules including source NAT, destination NAT, and bidirectional rules. Reads config at: /config/.../rulebase/nat/rules.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/nat/rules");

--- a/src/tools/network.ts
+++ b/src/tools/network.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerNetworkTools(server: McpServer) {
   server.tool(
     "get_interfaces",
-    "Get all network interfaces with their status, IP addresses, and configuration",
+    "[READ-ONLY] Retrieves all network interfaces with their status, IP addresses, and configuration. Executes: show interface all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><interface>all</interface></show>");
@@ -14,7 +14,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_zones",
-    "Get all security zones configured on the firewall",
+    "[READ-ONLY] Retrieves all security zones configured on the firewall. Reads config at: /config/.../vsys/entry/zone.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/zone");
@@ -24,7 +24,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_routing_table",
-    "Get the current routing table from the firewall",
+    "[READ-ONLY] Retrieves the current routing table from the firewall. Executes: show routing route.",
     {},
     async () => {
       const result = await executeOpCommand("<show><routing><route></route></routing></show>");
@@ -34,7 +34,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_arp_table",
-    "Get the ARP table entries from the firewall",
+    "[READ-ONLY] Retrieves ARP table entries from the firewall. Executes: show arp entry all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><arp><entry>all</entry></arp></show>");
@@ -44,7 +44,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_vlans",
-    "Get VLAN configuration from the firewall",
+    "[READ-ONLY] Retrieves VLAN configuration from the firewall. Reads config at: /config/.../network/vlan.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/network/vlan");
@@ -54,7 +54,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_dhcp_leases",
-    "Get DHCP server lease information",
+    "[READ-ONLY] Retrieves DHCP server lease information. Executes: show dhcp server lease all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><dhcp><server><lease>all</lease></server></dhcp></show>");
@@ -64,7 +64,7 @@ export function registerNetworkTools(server: McpServer) {
 
   server.tool(
     "get_dns_proxy",
-    "Get DNS proxy configuration",
+    "[READ-ONLY] Retrieves DNS proxy configuration. Reads config at: /config/.../network/dns-proxy.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/network/dns-proxy");

--- a/src/tools/objects.ts
+++ b/src/tools/objects.ts
@@ -4,7 +4,7 @@ import { getConfig, formatResponse } from "../api/client.js";
 export function registerObjectsTools(server: McpServer) {
   server.tool(
     "get_address_objects",
-    "Get all address objects (IP addresses, ranges, FQDNs) defined on the firewall",
+    "[READ-ONLY] Retrieves all address objects (IP addresses, ranges, FQDNs) defined on the firewall. Reads config at: /config/.../vsys/entry/address.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address");
@@ -14,7 +14,7 @@ export function registerObjectsTools(server: McpServer) {
 
   server.tool(
     "get_address_groups",
-    "Get all address groups that contain multiple address objects",
+    "[READ-ONLY] Retrieves all address groups that contain multiple address objects. Reads config at: /config/.../vsys/entry/address-group.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group");
@@ -24,7 +24,7 @@ export function registerObjectsTools(server: McpServer) {
 
   server.tool(
     "get_service_objects",
-    "Get all service objects (port/protocol definitions) from the firewall",
+    "[READ-ONLY] Retrieves all service objects (port/protocol definitions) from the firewall. Reads config at: /config/.../vsys/entry/service.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/service");
@@ -34,7 +34,7 @@ export function registerObjectsTools(server: McpServer) {
 
   server.tool(
     "get_service_groups",
-    "Get all service groups that contain multiple service objects",
+    "[READ-ONLY] Retrieves all service groups that contain multiple service objects. Reads config at: /config/.../vsys/entry/service-group.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/service-group");
@@ -44,7 +44,7 @@ export function registerObjectsTools(server: McpServer) {
 
   server.tool(
     "get_application_filters",
-    "Get application filters used for application-based policy rules",
+    "[READ-ONLY] Retrieves application filters used for application-based policy rules. Reads config at: /config/.../vsys/entry/application-filter.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/application-filter");

--- a/src/tools/panorama.ts
+++ b/src/tools/panorama.ts
@@ -6,7 +6,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Managed Devices
   server.tool(
     "panorama_get_managed_devices",
-    "Get all firewalls managed by Panorama with their connection status",
+    "[READ-ONLY] Retrieves all firewalls managed by Panorama with their connection status. Executes: show devices all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><devices><all></all></devices></show>");
@@ -16,7 +16,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_device_groups",
-    "Get all device groups configured in Panorama",
+    "[READ-ONLY] Retrieves all device groups configured in Panorama. Reads config at: /config/.../device-group.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/device-group");
@@ -27,7 +27,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Templates
   server.tool(
     "panorama_get_templates",
-    "Get all templates configured in Panorama",
+    "[READ-ONLY] Retrieves all templates configured in Panorama. Reads config at: /config/.../template.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/template");
@@ -37,7 +37,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_template_stacks",
-    "Get all template stacks configured in Panorama",
+    "[READ-ONLY] Retrieves all template stacks configured in Panorama. Reads config at: /config/.../template-stack.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/template-stack");
@@ -48,7 +48,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Shared Objects (Panorama-level)
   server.tool(
     "panorama_get_shared_address_objects",
-    "Get shared address objects defined at Panorama level",
+    "[READ-ONLY] Retrieves shared address objects defined at Panorama level. Reads config at: /config/shared/address.",
     {},
     async () => {
       const result = await getConfig("/config/shared/address");
@@ -58,7 +58,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_shared_address_groups",
-    "Get shared address groups defined at Panorama level",
+    "[READ-ONLY] Retrieves shared address groups defined at Panorama level. Reads config at: /config/shared/address-group.",
     {},
     async () => {
       const result = await getConfig("/config/shared/address-group");
@@ -68,7 +68,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_shared_service_objects",
-    "Get shared service objects defined at Panorama level",
+    "[READ-ONLY] Retrieves shared service objects defined at Panorama level. Reads config at: /config/shared/service.",
     {},
     async () => {
       const result = await getConfig("/config/shared/service");
@@ -78,7 +78,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_shared_service_groups",
-    "Get shared service groups defined at Panorama level",
+    "[READ-ONLY] Retrieves shared service groups defined at Panorama level. Reads config at: /config/shared/service-group.",
     {},
     async () => {
       const result = await getConfig("/config/shared/service-group");
@@ -89,7 +89,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Pre/Post Rules (Panorama-pushed policies)
   server.tool(
     "panorama_get_pre_rules",
-    "Get pre-rules from a device group (rules pushed before local firewall rules)",
+    "[READ-ONLY] Retrieves pre-rules from a device group (rules pushed before local firewall rules). Reads config at: /config/.../device-group/entry/pre-rulebase/security/rules.",
     {
       device_group: z.string().describe("Name of the device group"),
     },
@@ -103,7 +103,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_post_rules",
-    "Get post-rules from a device group (rules pushed after local firewall rules)",
+    "[READ-ONLY] Retrieves post-rules from a device group (rules pushed after local firewall rules). Reads config at: /config/.../device-group/entry/post-rulebase/security/rules.",
     {
       device_group: z.string().describe("Name of the device group"),
     },
@@ -117,7 +117,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_device_group_nat_rules",
-    "Get NAT rules from a device group (pre and post rules)",
+    "[READ-ONLY] Retrieves NAT rules from a device group (pre or post rulebase). Reads config at: /config/.../device-group/entry/{pre|post}-rulebase/nat/rules.",
     {
       device_group: z.string().describe("Name of the device group"),
       rulebase: z.enum(["pre", "post"]).describe("Rulebase type: 'pre' or 'post'"),
@@ -133,7 +133,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Log Collectors
   server.tool(
     "panorama_get_log_collectors",
-    "Get log collector configuration and status from Panorama",
+    "[READ-ONLY] Retrieves log collector configuration and status from Panorama. Executes: show log-collector all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><log-collector><all></all></log-collector></show>");
@@ -143,7 +143,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_collector_groups",
-    "Get collector group configuration from Panorama",
+    "[READ-ONLY] Retrieves collector group configuration from Panorama. Reads config at: /config/.../log-collector-group.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/log-collector-group");
@@ -154,7 +154,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Push Status
   server.tool(
     "panorama_get_push_status",
-    "Get the status of the last configuration push to managed devices",
+    "[READ-ONLY] Retrieves the status of the last configuration push to managed devices. Executes: show config push status.",
     {},
     async () => {
       const result = await executeOpCommand("<show><config><push><status></status></push></config></show>");
@@ -165,7 +165,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Commit Status
   server.tool(
     "panorama_get_commit_status",
-    "Get the status of pending commits in Panorama",
+    "[READ-ONLY] Retrieves the status of pending commits in Panorama. Executes: show jobs all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><jobs><all></all></jobs></show>");
@@ -176,7 +176,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Software/Content Versions on Managed Devices
   server.tool(
     "panorama_get_managed_device_software",
-    "Get software and content versions on all managed firewalls",
+    "[READ-ONLY] Retrieves software and content versions on all managed firewalls. Executes: show devices all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><devices><all></all></devices></show>");
@@ -187,7 +187,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Panorama HA
   server.tool(
     "panorama_get_ha_status",
-    "Get Panorama high-availability status (for Panorama HA pairs)",
+    "[READ-ONLY] Retrieves Panorama high-availability status for Panorama HA pairs. Executes: show high-availability state.",
     {},
     async () => {
       const result = await executeOpCommand("<show><high-availability><state></state></high-availability></show>");
@@ -198,7 +198,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Device Group Hierarchy
   server.tool(
     "panorama_get_device_group_hierarchy",
-    "Get the device group hierarchy showing parent-child relationships",
+    "[READ-ONLY] Retrieves the device group hierarchy showing parent-child relationships. Reads config at: /config/readonly/.../device-group.",
     {},
     async () => {
       const result = await getConfig("/config/readonly/devices/entry[@name='localhost.localdomain']/device-group");
@@ -209,7 +209,7 @@ export function registerPanoramaTools(server: McpServer) {
   // Shared Security Profiles
   server.tool(
     "panorama_get_shared_security_profiles",
-    "Get shared security profiles defined at Panorama level",
+    "[READ-ONLY] Retrieves shared security profiles defined at Panorama level. Reads config at: /config/shared/profiles.",
     {},
     async () => {
       const result = await getConfig("/config/shared/profiles");
@@ -219,7 +219,7 @@ export function registerPanoramaTools(server: McpServer) {
 
   server.tool(
     "panorama_get_shared_profile_groups",
-    "Get shared security profile groups defined at Panorama level",
+    "[READ-ONLY] Retrieves shared security profile groups defined at Panorama level. Reads config at: /config/shared/profile-group.",
     {},
     async () => {
       const result = await getConfig("/config/shared/profile-group");

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerSecurityTools(server: McpServer) {
   server.tool(
     "get_security_rules",
-    "Get all security policy rules from the firewall",
+    "[READ-ONLY] Retrieves all security policy rules from the firewall. Reads config at: /config/.../rulebase/security/rules.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules");
@@ -14,7 +14,7 @@ export function registerSecurityTools(server: McpServer) {
 
   server.tool(
     "get_security_profiles",
-    "Get security profiles including antivirus, vulnerability, spyware, URL filtering profiles",
+    "[READ-ONLY] Retrieves security profiles including antivirus, vulnerability, spyware, and URL filtering profiles. Reads config at: /config/.../vsys/entry/profiles.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/profiles");
@@ -24,7 +24,7 @@ export function registerSecurityTools(server: McpServer) {
 
   server.tool(
     "get_security_profile_groups",
-    "Get security profile groups that combine multiple security profiles",
+    "[READ-ONLY] Retrieves security profile groups that combine multiple security profiles. Reads config at: /config/.../vsys/entry/profile-group.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/profile-group");
@@ -34,7 +34,7 @@ export function registerSecurityTools(server: McpServer) {
 
   server.tool(
     "get_pbf_rules",
-    "Get policy-based forwarding rules",
+    "[READ-ONLY] Retrieves policy-based forwarding (PBF) rules. Reads config at: /config/.../rulebase/pbf/rules.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/pbf/rules");
@@ -44,7 +44,7 @@ export function registerSecurityTools(server: McpServer) {
 
   server.tool(
     "get_dos_profiles",
-    "Get DoS protection profiles",
+    "[READ-ONLY] Retrieves DoS protection profiles. Reads config at: /config/.../profiles/dos-protection.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/profiles/dos-protection");
@@ -54,7 +54,7 @@ export function registerSecurityTools(server: McpServer) {
 
   server.tool(
     "get_qos_rules",
-    "Get QoS policy rules",
+    "[READ-ONLY] Retrieves QoS policy rules. Reads config at: /config/.../rulebase/qos/rules.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/qos/rules");

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, formatResponse } from "../api/client.js";
 export function registerSystemTools(server: McpServer) {
   server.tool(
     "get_firewall_info",
-    "Get system information from the PanOS firewall including hostname, model, serial, software version",
+    "[READ-ONLY] Retrieves system information (hostname, model, serial, software version) from the PanOS firewall. Executes: show system info.",
     {},
     async () => {
       const result = await executeOpCommand("<show><system><info></info></system></show>");
@@ -17,7 +17,7 @@ export function registerSystemTools(server: McpServer) {
 
   server.tool(
     "get_ha_status",
-    "Get high-availability (HA) state and peer information from the firewall",
+    "[READ-ONLY] Retrieves high-availability (HA) state and peer information from the firewall. Executes: show high-availability state.",
     {},
     async () => {
       const result = await executeOpCommand("<show><high-availability><state></state></high-availability></show>");
@@ -27,7 +27,7 @@ export function registerSystemTools(server: McpServer) {
 
   server.tool(
     "get_active_sessions",
-    "Get active session count and summary from the firewall",
+    "[READ-ONLY] Retrieves active session count and summary from the firewall. Executes: show session info.",
     {},
     async () => {
       const result = await executeOpCommand("<show><session><info></info></session></show>");
@@ -37,7 +37,7 @@ export function registerSystemTools(server: McpServer) {
 
   server.tool(
     "get_system_resources",
-    "Get system resource utilization including CPU, memory, and disk usage",
+    "[READ-ONLY] Retrieves system resource utilization including CPU, memory, and disk usage. Executes: show system resources.",
     {},
     async () => {
       const result = await executeOpCommand("<show><system><resources></resources></system></show>");

--- a/src/tools/threat.ts
+++ b/src/tools/threat.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerThreatTools(server: McpServer) {
   server.tool(
     "get_wildfire_status",
-    "Get WildFire cloud connection status and statistics",
+    "[READ-ONLY] Retrieves WildFire cloud connection status and statistics. Executes: show wildfire status.",
     {},
     async () => {
       const result = await executeOpCommand("<show><wildfire><status></status></wildfire></show>");
@@ -14,7 +14,7 @@ export function registerThreatTools(server: McpServer) {
 
   server.tool(
     "get_antivirus_version",
-    "Get current antivirus signature version and release date",
+    "[READ-ONLY] Retrieves current antivirus, threat, and WildFire signature versions and release dates. Executes: show system info (extracts signature fields).",
     {},
     async () => {
       const result = await executeOpCommand("<show><system><info></info></system></show>");
@@ -35,7 +35,7 @@ export function registerThreatTools(server: McpServer) {
 
   server.tool(
     "get_content_versions",
-    "Get available content update versions (antivirus, applications, threats)",
+    "[READ-ONLY] Retrieves available content update versions (antivirus, applications, threats). Executes: request content upgrade info.",
     {},
     async () => {
       const result = await executeOpCommand("<request><content><upgrade><info></info></upgrade></content></request>");
@@ -45,7 +45,7 @@ export function registerThreatTools(server: McpServer) {
 
   server.tool(
     "get_url_categories",
-    "Get predefined URL filtering categories",
+    "[READ-ONLY] Retrieves predefined URL filtering categories. Reads config at: /config/predefined/pan-url-categories.",
     {},
     async () => {
       const result = await getConfig("/config/predefined/pan-url-categories");

--- a/src/tools/userid.ts
+++ b/src/tools/userid.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerUserIdTools(server: McpServer) {
   server.tool(
     "get_userid_mappings",
-    "Get IP to user mappings from User-ID (shows which users are mapped to which IP addresses)",
+    "[READ-ONLY] Retrieves IP-to-user mappings from User-ID, showing which users are mapped to which IP addresses. Executes: show user ip-user-mapping all.",
     {},
     async () => {
       const result = await executeOpCommand("<show><user><ip-user-mapping><all></all></ip-user-mapping></user></show>");
@@ -14,7 +14,7 @@ export function registerUserIdTools(server: McpServer) {
 
   server.tool(
     "get_userid_groups",
-    "Get user groups known to the firewall via User-ID",
+    "[READ-ONLY] Retrieves user groups known to the firewall via User-ID. Executes: show user group list.",
     {},
     async () => {
       const result = await executeOpCommand("<show><user><group><list></list></group></user></show>");
@@ -24,7 +24,7 @@ export function registerUserIdTools(server: McpServer) {
 
   server.tool(
     "get_userid_config",
-    "Get User-ID configuration settings including agent configuration and group mapping",
+    "[READ-ONLY] Retrieves User-ID configuration settings including agent configuration and group mapping. Reads config at: /config/.../vsys/entry/user-id-agent.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/user-id-agent");

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -5,7 +5,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerUtilityTools(server: McpServer) {
   server.tool(
     "run_op_command",
-    "Execute a custom XML operational command on the firewall",
+    "[ADVANCED] Executes an arbitrary PanOS operational XML command. The command will be sent directly to the firewall API. Use with caution — the command could be read-only or state-modifying depending on its content.",
     {
       command: z.string().describe("XML operational command to execute (e.g., '<show><system><info></info></system></show>')"),
     },
@@ -17,7 +17,7 @@ export function registerUtilityTools(server: McpServer) {
 
   server.tool(
     "get_config_xpath",
-    "Get configuration at a specific XPath location",
+    "[READ-ONLY] Retrieves configuration at a specific XPath location. This is a flexible read tool for querying any part of the PanOS configuration tree.",
     {
       xpath: z.string().describe("XPath to the configuration element (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/network')"),
     },

--- a/src/tools/vpn.ts
+++ b/src/tools/vpn.ts
@@ -4,7 +4,7 @@ import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
 export function registerVpnTools(server: McpServer) {
   server.tool(
     "get_ipsec_tunnels",
-    "Get IPSec VPN tunnel status and security associations",
+    "[READ-ONLY] Retrieves IPSec VPN tunnel status and security associations. Executes: show vpn ipsec-sa.",
     {},
     async () => {
       const result = await executeOpCommand("<show><vpn><ipsec-sa></ipsec-sa></vpn></show>");
@@ -14,7 +14,7 @@ export function registerVpnTools(server: McpServer) {
 
   server.tool(
     "get_globalprotect_users",
-    "Get currently connected GlobalProtect VPN users",
+    "[READ-ONLY] Retrieves currently connected GlobalProtect VPN users. Executes: show global-protect-gateway current-user.",
     {},
     async () => {
       const result = await executeOpCommand("<show><global-protect-gateway><current-user></current-user></global-protect-gateway></show>");
@@ -24,7 +24,7 @@ export function registerVpnTools(server: McpServer) {
 
   server.tool(
     "get_globalprotect_config",
-    "Get GlobalProtect gateway and portal configuration",
+    "[READ-ONLY] Retrieves GlobalProtect gateway and portal configuration. Reads config at: /config/.../vsys/entry/global-protect.",
     {},
     async () => {
       const result = await getConfig("/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/global-protect");


### PR DESCRIPTION
## Summary
- Added `[READ-ONLY]`, `[MODIFIES CONFIG]`, and `[ADVANCED]` prefixes to all 71 MCP tool descriptions across 15 files
- Each description now includes the specific PanOS op command or config XPath being accessed
- State-modifying tools (`set_config`, `delete_config`, `commit`, `panorama_push_to_devices`) explicitly warn about candidate config staging, commit requirements, and live traffic impact

## Test plan
- [x] `npm run build` compiles without errors
- [ ] Verify tool descriptions render correctly in Claude's tool approval UI
- [ ] Spot-check a few tools to confirm descriptions match actual API calls
