### PR TITLE
Add Zod input validation and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# PanOS MCP Server
+
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server for interacting with Palo Alto Networks PanOS firewalls and Panorama. Provides 51 tools across 15 modules for firewall management, monitoring, and configuration.
+
+## Features
+
+- **Read-only inspection** of firewall state, policies, objects, logs, and more
+- **Configuration management** via XPath-based set/delete with staged commits
+- **Panorama support** for centralized management of device groups, templates, and shared objects
+- **Input validation** with Zod schemas for early error detection
+- **Safety labels** on every tool: `[READ-ONLY]`, `[MODIFIES CONFIG]`, or `[ADVANCED]`
+
+## Prerequisites
+
+- Node.js 18+
+- A PanOS firewall or Panorama appliance with API access enabled
+- A PanOS API key ([how to generate](https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key))
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Configuration
+
+Set the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `PANOS_HOST` | Firewall or Panorama hostname/IP |
+| `PANOS_API_KEY` | API key for authentication |
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop MCP configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "panos": {
+      "command": "node",
+      "args": ["/path/to/panos-mcp/dist/index.js"],
+      "env": {
+        "PANOS_HOST": "your-firewall-or-panorama",
+        "PANOS_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+## Tool Categories
+
+| Category | Tools | Description |
+|----------|-------|-------------|
+| System | 4 | Firewall info, HA status, sessions, resources |
+| Network | 7 | Interfaces, zones, routing, ARP, VLANs, DHCP, DNS proxy |
+| Security | 6 | Security rules, profiles, profile groups, PBF, DoS, QoS |
+| Objects | 5 | Address/service objects and groups, application filters |
+| NAT | 1 | NAT rules |
+| User-ID | 3 | User-IP mappings, groups, config |
+| Admin | 3 | Admins, roles, auth profiles |
+| VPN | 3 | IPSec tunnels, GlobalProtect users and config |
+| Panorama | 20 | Device groups, templates, shared objects, pre/post rules, push status, HA |
+| Logs | 4 | Traffic, threat, system, and config logs |
+| Threat | 4 | WildFire, antivirus, content versions, URL categories |
+| Certificates | 3 | Certificates, decryption rules and profiles |
+| Licenses | 2 | License info and usage |
+| Config | 4 | Set/delete config, commit, Panorama push |
+| Utility | 2 | Arbitrary op commands, XPath config reads |
+
+## Safety Labels
+
+Every tool is labeled to indicate its impact:
+
+- **`[READ-ONLY]`** — Only reads data; no changes to the firewall
+- **`[MODIFIES CONFIG]`** — Stages or commits configuration changes that affect live traffic
+- **`[ADVANCED]`** — Accepts arbitrary commands; impact depends on the input
+
+## Development
+
+```bash
+# Watch mode (rebuild on changes)
+npm run dev
+
+# Build
+npm run build
+
+# Run the server
+npm run start
+```
+
+## License
+
+ISC

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "fast-xml-parser": "^4.5.1",
-        "undici": "^7.3.0"
+        "undici": "^7.3.0",
+        "zod": "^4.0"
       },
       "bin": {
         "panos-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "fast-xml-parser": "^4.5.1",
-    "undici": "^7.3.0"
+    "undici": "^7.3.0",
+    "zod": "^4.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.2",

--- a/src/schemas/panos.ts
+++ b/src/schemas/panos.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const configXpath = z
+  .string()
+  .startsWith("/config")
+  .describe("XPath to a configuration location (must start with '/config')");
+
+export const deviceGroup = z
+  .string()
+  .min(1)
+  .describe("Name of the device group");
+
+export const nlogsSchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(5000)
+  .optional()
+  .describe("Number of logs to retrieve (default: 20, max: 5000)");

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -1,14 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { setConfig, deleteConfig, commitConfig, commitAll, formatResponse } from "../api/client.js";
+import { configXpath, deviceGroup } from "../schemas/panos.js";
 
 export function registerConfigTools(server: McpServer) {
   server.tool(
     "set_config",
     "[MODIFIES CONFIG] Sets or creates configuration at a specific XPath location on the firewall. Changes are staged in the candidate config and require a separate 'commit' to take effect on the running firewall.",
     {
-      xpath: z.string().describe("XPath to the configuration location (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address')"),
-      element: z.string().describe("XML element to set at the xpath location (e.g., '<entry name=\"test-addr\"><ip-netmask>10.0.0.1/32</ip-netmask></entry>')"),
+      xpath: configXpath.describe("XPath to the configuration location (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address')"),
+      element: z.string().min(1).startsWith("<").describe("XML element to set at the xpath location (e.g., '<entry name=\"test-addr\"><ip-netmask>10.0.0.1/32</ip-netmask></entry>')"),
     },
     async ({ xpath, element }) => {
       const result = await setConfig(xpath, element);
@@ -20,7 +21,7 @@ export function registerConfigTools(server: McpServer) {
     "delete_config",
     "[MODIFIES CONFIG] Deletes configuration at a specific XPath location on the firewall. Changes are staged in the candidate config and require a separate 'commit' to take effect.",
     {
-      xpath: z.string().describe("XPath to the configuration element to delete (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address/entry[@name=\"test-addr\"]')"),
+      xpath: configXpath.describe("XPath to the configuration element to delete (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/vsys/entry[@name=\"vsys1\"]/address/entry[@name=\"test-addr\"]')"),
     },
     async ({ xpath }) => {
       const result = await deleteConfig(xpath);
@@ -32,8 +33,8 @@ export function registerConfigTools(server: McpServer) {
     "commit",
     "[MODIFIES CONFIG] Commits all pending (staged) configuration changes to the running firewall. This activates changes made by set_config/delete_config. This action affects live traffic.",
     {
-      description: z.string().optional().describe("Optional commit description/comment"),
-      partial_admin: z.string().optional().describe("Commit only changes made by this admin user"),
+      description: z.string().max(512).optional().describe("Optional commit description/comment"),
+      partial_admin: z.string().min(1).max(63).optional().describe("Commit only changes made by this admin user"),
     },
     async ({ description, partial_admin }) => {
       let cmd = "<commit>";
@@ -53,8 +54,8 @@ export function registerConfigTools(server: McpServer) {
     "panorama_push_to_devices",
     "[MODIFIES CONFIG] Pushes configuration from Panorama to managed firewall devices. This deploys policy and object changes to production firewalls in the specified device group. This action affects live traffic on managed devices.",
     {
-      device_group: z.string().describe("Device group name to push to"),
-      description: z.string().optional().describe("Optional push description"),
+      device_group: deviceGroup.describe("Device group name to push to"),
+      description: z.string().max(512).optional().describe("Optional push description"),
       include_template: z.boolean().optional().describe("Include template stack (default: false)"),
     },
     async ({ device_group, description, include_template }) => {

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,14 +1,15 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { executeOpCommand, formatResponse } from "../api/client.js";
+import { nlogsSchema } from "../schemas/panos.js";
 
 export function registerLogsTools(server: McpServer) {
   server.tool(
     "get_traffic_logs",
     "[READ-ONLY] Retrieves recent traffic logs from the firewall. Executes: show log traffic. Supports filtering by query and limiting result count.",
     {
-      nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
-      query: z.string().optional().describe("Filter query (e.g., '( addr.src in 10.0.0.0/8 )')"),
+      nlogs: nlogsSchema,
+      query: z.string().max(2048).optional().describe("Filter query (e.g., '( addr.src in 10.0.0.0/8 )')"),
     },
     async ({ nlogs, query }) => {
       const limit = nlogs || 20;
@@ -26,8 +27,8 @@ export function registerLogsTools(server: McpServer) {
     "get_threat_logs",
     "[READ-ONLY] Retrieves recent threat logs from the firewall. Executes: show log threat. Supports filtering by query and limiting result count.",
     {
-      nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
-      query: z.string().optional().describe("Filter query (e.g., '( severity eq critical )')"),
+      nlogs: nlogsSchema,
+      query: z.string().max(2048).optional().describe("Filter query (e.g., '( severity eq critical )')"),
     },
     async ({ nlogs, query }) => {
       const limit = nlogs || 20;
@@ -45,8 +46,8 @@ export function registerLogsTools(server: McpServer) {
     "get_system_logs",
     "[READ-ONLY] Retrieves recent system logs from the firewall. Executes: show log system. Supports filtering by query and limiting result count.",
     {
-      nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
-      query: z.string().optional().describe("Filter query (e.g., '( severity eq critical )')"),
+      nlogs: nlogsSchema,
+      query: z.string().max(2048).optional().describe("Filter query (e.g., '( severity eq critical )')"),
     },
     async ({ nlogs, query }) => {
       const limit = nlogs || 20;
@@ -64,8 +65,8 @@ export function registerLogsTools(server: McpServer) {
     "get_config_logs",
     "[READ-ONLY] Retrieves recent configuration change logs from the firewall. Executes: show log config. Supports filtering by query and limiting result count.",
     {
-      nlogs: z.number().optional().describe("Number of logs to retrieve (default: 20, max: 5000)"),
-      query: z.string().optional().describe("Filter query"),
+      nlogs: nlogsSchema,
+      query: z.string().max(2048).optional().describe("Filter query"),
     },
     async ({ nlogs, query }) => {
       const limit = nlogs || 20;

--- a/src/tools/panorama.ts
+++ b/src/tools/panorama.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
+import { deviceGroup } from "../schemas/panos.js";
 
 export function registerPanoramaTools(server: McpServer) {
   // Managed Devices
@@ -91,7 +92,7 @@ export function registerPanoramaTools(server: McpServer) {
     "panorama_get_pre_rules",
     "[READ-ONLY] Retrieves pre-rules from a device group (rules pushed before local firewall rules). Reads config at: /config/.../device-group/entry/pre-rulebase/security/rules.",
     {
-      device_group: z.string().describe("Name of the device group"),
+      device_group: deviceGroup,
     },
     async ({ device_group }) => {
       const result = await getConfig(
@@ -105,7 +106,7 @@ export function registerPanoramaTools(server: McpServer) {
     "panorama_get_post_rules",
     "[READ-ONLY] Retrieves post-rules from a device group (rules pushed after local firewall rules). Reads config at: /config/.../device-group/entry/post-rulebase/security/rules.",
     {
-      device_group: z.string().describe("Name of the device group"),
+      device_group: deviceGroup,
     },
     async ({ device_group }) => {
       const result = await getConfig(
@@ -119,7 +120,7 @@ export function registerPanoramaTools(server: McpServer) {
     "panorama_get_device_group_nat_rules",
     "[READ-ONLY] Retrieves NAT rules from a device group (pre or post rulebase). Reads config at: /config/.../device-group/entry/{pre|post}-rulebase/nat/rules.",
     {
-      device_group: z.string().describe("Name of the device group"),
+      device_group: deviceGroup,
       rulebase: z.enum(["pre", "post"]).describe("Rulebase type: 'pre' or 'post'"),
     },
     async ({ device_group, rulebase }) => {

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -1,13 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { executeOpCommand, getConfig, formatResponse } from "../api/client.js";
+import { configXpath } from "../schemas/panos.js";
 
 export function registerUtilityTools(server: McpServer) {
   server.tool(
     "run_op_command",
     "[ADVANCED] Executes an arbitrary PanOS operational XML command. The command will be sent directly to the firewall API. Use with caution — the command could be read-only or state-modifying depending on its content.",
     {
-      command: z.string().describe("XML operational command to execute (e.g., '<show><system><info></info></system></show>')"),
+      command: z.string().min(1).startsWith("<").describe("XML operational command to execute (e.g., '<show><system><info></info></system></show>')"),
     },
     async ({ command }) => {
       const result = await executeOpCommand(command);
@@ -19,7 +20,7 @@ export function registerUtilityTools(server: McpServer) {
     "get_config_xpath",
     "[READ-ONLY] Retrieves configuration at a specific XPath location. This is a flexible read tool for querying any part of the PanOS configuration tree.",
     {
-      xpath: z.string().describe("XPath to the configuration element (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/network')"),
+      xpath: configXpath.describe("XPath to the configuration element (e.g., '/config/devices/entry[@name=\"localhost.localdomain\"]/network')"),
     },
     async ({ xpath }) => {
       const result = await getConfig(xpath);


### PR DESCRIPTION
## Summary
- Add shared Zod schemas (`configXpath`, `deviceGroup`, `nlogsSchema`) in `src/schemas/panos.ts` and apply validation constraints across 13 tools in config, logs, panorama, and utility modules
- Add `zod` as an explicit dependency (previously only installed transitively)
- Add comprehensive project README with features, installation, configuration, tool categories, and safety labels

## Test plan
- [x] `npm run build` compiles without errors
- [ ] Verify invalid inputs (empty strings, out-of-range nlogs, non-XML elements) are rejected with clear Zod error messages
- [ ] Verify valid inputs continue to work as before
