### PR TITLE
feat: HTTP and SOCKS proxy support for PanOS API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,34 @@ curl -k 'https://YOUR-FIREWALL/api/?type=keygen&user=admin&password=YOUR-PASSWOR
 
 See [PanOS documentation](https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key) for details.
 
+## Proxy support
+
+If your firewall is reachable only via a proxy (management network behind a jump host, remote access via SOCKS5, corporate HTTP proxy), set one of the following environment variables before starting the server:
+
+| Variable | Purpose |
+|---|---|
+| `PANOS_PROXY` | **Explicit override.** Used regardless of `NO_PROXY`. Recommended for MCP deployments. |
+| `HTTPS_PROXY` / `https_proxy` | Standard — same semantics as most HTTP clients. |
+| `HTTP_PROXY` / `http_proxy` | Fallback. |
+| `ALL_PROXY` / `all_proxy` | Fallback (common for SOCKS). |
+| `NO_PROXY` / `no_proxy` | Comma-separated list of hostnames/suffixes to bypass. `*` disables proxying entirely. Ignored when `PANOS_PROXY` is set. |
+
+Supported URL schemes:
+
+- `http://[user:pass@]host:port` — HTTP CONNECT proxy
+- `https://[user:pass@]host:port` — HTTPS CONNECT proxy
+- `socks5://[user:pass@]host:port` — SOCKS5, **client-side** DNS
+- `socks5h://[user:pass@]host:port` — SOCKS5, **proxy-side** DNS (use this when the firewall hostname only resolves on the far side of the proxy)
+- `socks4://[user@]host:port` / `socks4a://[user@]host:port`
+
+Example — SOCKS5 with remote DNS:
+
+```bash
+export PANOS_PROXY=socks5h://10.0.1.168:2080
+```
+
+Self-signed firewall certificates are accepted through the proxy tunnel (the server already disables cert validation for the PanOS target).
+
 ## Development
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "panos-mcp",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panos-mcp",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@napi-rs/keyring": "^1.2.0",
         "fast-xml-parser": "^4.5.1",
+        "socks": "^2.8.3",
         "undici": "^7.3.0",
         "zod": "^4.0"
       },
@@ -2533,6 +2534,30 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/keyring": "^1.2.0",
     "fast-xml-parser": "^4.5.1",
+    "socks": "^2.8.3",
     "undici": "^7.3.0",
     "zod": "^4.0"
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,7 @@
 import { XMLParser } from "fast-xml-parser";
-import { Agent, fetch } from "undici";
+import { fetch } from "undici";
 import { resolveFirewall, isMultiFirewall } from "../config/firewalls.js";
+import { buildDispatcher } from "./proxy.js";
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -55,13 +56,11 @@ function connectError(error: unknown): string {
 }
 
 async function makeRequest(url: string): Promise<ApiResponse> {
-  const agent = new Agent({
-    connect: { rejectUnauthorized: false },
-  });
+  const dispatcher = buildDispatcher(url);
 
   const response = await fetch(url, {
     method: "GET",
-    dispatcher: agent,
+    dispatcher,
   });
 
   if (!response.ok) {

--- a/src/api/proxy.ts
+++ b/src/api/proxy.ts
@@ -1,0 +1,215 @@
+import { Agent, ProxyAgent, type Dispatcher } from "undici";
+import { connect as tlsConnect } from "tls";
+import { SocksClient } from "socks";
+
+/**
+ * Proxy support for PanOS API requests.
+ *
+ * Resolution order (first non-empty wins):
+ *   1. PANOS_PROXY         — explicit override, used regardless of NO_PROXY
+ *   2. HTTPS_PROXY / https_proxy
+ *   3. HTTP_PROXY  / http_proxy
+ *   4. ALL_PROXY   / all_proxy
+ *
+ * Supported URL schemes:
+ *   - http://[user:pass@]host:port   — HTTP CONNECT proxy (undici ProxyAgent)
+ *   - https://[user:pass@]host:port  — HTTPS CONNECT proxy (TLS to proxy)
+ *   - socks5://[user:pass@]host:port — SOCKS5, client-side DNS
+ *   - socks5h://[user:pass@]host:port — SOCKS5, proxy-side DNS (recommended)
+ *   - socks4://[user@]host:port      — SOCKS4
+ *   - socks4a://[user@]host:port     — SOCKS4a (proxy-side DNS)
+ *
+ * NO_PROXY (comma-separated): bypassed unless PANOS_PROXY is set. Entries may be
+ * exact hostnames, suffixes (".example.com" or "example.com"), or "*" to bypass all.
+ */
+
+export type ProxyScheme = "http" | "https" | "socks5" | "socks5h" | "socks4" | "socks4a";
+
+export interface ParsedProxy {
+  scheme: ProxyScheme;
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  /** Source env var the proxy came from, for diagnostics. */
+  source: string;
+  /** True if NO_PROXY should be ignored (PANOS_PROXY override). */
+  forced: boolean;
+}
+
+const SCHEME_DEFAULT_PORT: Record<ProxyScheme, number> = {
+  http: 80,
+  https: 443,
+  socks5: 1080,
+  socks5h: 1080,
+  socks4: 1080,
+  socks4a: 1080,
+};
+
+/**
+ * Parse a proxy URL. Returns null if the string is empty or malformed.
+ * Exposed for tests.
+ */
+export function parseProxyUrl(raw: string, source: string, forced: boolean): ParsedProxy | null {
+  if (!raw) return null;
+  // Allow bare "host:port" — default to http
+  const normalized = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `http://${raw}`;
+  let url: URL;
+  try {
+    url = new URL(normalized);
+  } catch {
+    return null;
+  }
+  const scheme = url.protocol.replace(/:$/, "").toLowerCase() as ProxyScheme;
+  if (!(scheme in SCHEME_DEFAULT_PORT)) return null;
+  const host = url.hostname;
+  if (!host) return null;
+  const port = url.port ? Number(url.port) : SCHEME_DEFAULT_PORT[scheme];
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) return null;
+  return {
+    scheme,
+    host,
+    port,
+    username: url.username ? decodeURIComponent(url.username) : undefined,
+    password: url.password ? decodeURIComponent(url.password) : undefined,
+    source,
+    forced,
+  };
+}
+
+/**
+ * Resolve the active proxy from env vars. Returns null when no proxy is configured.
+ */
+export function resolveProxyFromEnv(env: NodeJS.ProcessEnv = process.env): ParsedProxy | null {
+  const candidates: Array<{ name: string; forced: boolean }> = [
+    { name: "PANOS_PROXY", forced: true },
+    { name: "HTTPS_PROXY", forced: false },
+    { name: "https_proxy", forced: false },
+    { name: "HTTP_PROXY", forced: false },
+    { name: "http_proxy", forced: false },
+    { name: "ALL_PROXY", forced: false },
+    { name: "all_proxy", forced: false },
+  ];
+  for (const { name, forced } of candidates) {
+    const raw = env[name]?.trim();
+    if (!raw) continue;
+    const parsed = parseProxyUrl(raw, name, forced);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+/**
+ * Return true if `host` matches an entry in NO_PROXY.
+ * Supports exact match, suffix match, leading-dot suffix, and "*".
+ * Exposed for tests.
+ */
+export function shouldBypassProxy(host: string, noProxyEnv: string | undefined): boolean {
+  if (!noProxyEnv) return false;
+  const target = host.toLowerCase();
+  for (const rawEntry of noProxyEnv.split(",")) {
+    const entry = rawEntry.trim().toLowerCase();
+    if (!entry) continue;
+    if (entry === "*") return true;
+    if (entry === target) return true;
+    const suffix = entry.startsWith(".") ? entry : `.${entry}`;
+    if (target.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+/**
+ * Build an undici Dispatcher for a given target URL.
+ * Returns an Agent with `rejectUnauthorized: false` when no proxy applies.
+ */
+export function buildDispatcher(targetUrl: string, env: NodeJS.ProcessEnv = process.env): Dispatcher {
+  const proxy = resolveProxyFromEnv(env);
+  if (!proxy) return defaultAgent();
+
+  let targetHost = "";
+  try {
+    targetHost = new URL(targetUrl).hostname;
+  } catch {
+    // fall through — if the URL is invalid undici will reject it anyway
+  }
+  if (!proxy.forced && targetHost && shouldBypassProxy(targetHost, env.NO_PROXY ?? env.no_proxy)) {
+    return defaultAgent();
+  }
+
+  switch (proxy.scheme) {
+    case "http":
+    case "https":
+      return buildHttpProxyAgent(proxy);
+    case "socks5":
+    case "socks5h":
+    case "socks4":
+    case "socks4a":
+      return buildSocksAgent(proxy);
+  }
+}
+
+function defaultAgent(): Agent {
+  return new Agent({ connect: { rejectUnauthorized: false } });
+}
+
+function buildHttpProxyAgent(proxy: ParsedProxy): ProxyAgent {
+  const { scheme, host, port, username, password } = proxy;
+  const auth = username ? `${encodeURIComponent(username)}:${encodeURIComponent(password ?? "")}@` : "";
+  const uri = `${scheme}://${auth}${host}:${port}`;
+  // requestTls keeps self-signed PanOS certs working through CONNECT tunnel.
+  return new ProxyAgent({
+    uri,
+    requestTls: { rejectUnauthorized: false },
+    proxyTls: { rejectUnauthorized: false },
+  });
+}
+
+function buildSocksAgent(proxy: ParsedProxy): Agent {
+  const socksType: 4 | 5 = proxy.scheme.startsWith("socks5") ? 5 : 4;
+  return new Agent({
+    connect: async (opts: any, callback: (err: Error | null, socket: any) => void) => {
+      try {
+        const hostname: string = opts.hostname ?? opts.host;
+        const port: number = Number(opts.port) || (opts.protocol === "https:" ? 443 : 80);
+        const { socket } = await SocksClient.createConnection({
+          proxy: {
+            host: proxy.host,
+            port: proxy.port,
+            type: socksType,
+            userId: proxy.username,
+            password: proxy.password,
+          },
+          command: "connect",
+          destination: { host: hostname, port },
+        });
+
+        if (opts.protocol === "https:") {
+          const tlsSock = tlsConnect({
+            socket,
+            servername: opts.servername || hostname,
+            rejectUnauthorized: false,
+            ALPNProtocols: ["http/1.1"],
+          });
+          tlsSock.once("secureConnect", () => callback(null, tlsSock));
+          tlsSock.once("error", (err) => callback(err, null as any));
+        } else {
+          callback(null, socket);
+        }
+      } catch (err) {
+        callback(err as Error, null as any);
+      }
+    },
+  });
+}
+
+/**
+ * Human-readable description of the active proxy, for logs/diagnostics.
+ * Masks credentials. Returns null when no proxy is active.
+ */
+export function describeProxy(env: NodeJS.ProcessEnv = process.env): string | null {
+  const proxy = resolveProxyFromEnv(env);
+  if (!proxy) return null;
+  const creds = proxy.username ? `${proxy.username}:***@` : "";
+  return `${proxy.scheme}://${creds}${proxy.host}:${proxy.port} (from ${proxy.source})`;
+}
+

--- a/tests/api/proxy.test.ts
+++ b/tests/api/proxy.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseProxyUrl,
+  resolveProxyFromEnv,
+  shouldBypassProxy,
+  describeProxy,
+} from "../../src/api/proxy.js";
+
+describe("parseProxyUrl", () => {
+  it("parses socks5h with credentials", () => {
+    const p = parseProxyUrl("socks5h://user:p%40ss@10.0.1.168:2080", "PANOS_PROXY", true);
+    expect(p).toEqual({
+      scheme: "socks5h",
+      host: "10.0.1.168",
+      port: 2080,
+      username: "user",
+      password: "p@ss",
+      source: "PANOS_PROXY",
+      forced: true,
+    });
+  });
+
+  it("parses http without credentials", () => {
+    const p = parseProxyUrl("http://proxy.example.com:3128", "HTTP_PROXY", false);
+    expect(p).toMatchObject({ scheme: "http", host: "proxy.example.com", port: 3128 });
+    expect(p?.username).toBeUndefined();
+  });
+
+  it("applies default port per scheme", () => {
+    expect(parseProxyUrl("socks5://proxy.example.com", "X", false)?.port).toBe(1080);
+    expect(parseProxyUrl("http://proxy.example.com", "X", false)?.port).toBe(80);
+    expect(parseProxyUrl("https://proxy.example.com", "X", false)?.port).toBe(443);
+  });
+
+  it("treats bare host:port as http", () => {
+    expect(parseProxyUrl("10.0.1.168:2080", "X", false)).toMatchObject({
+      scheme: "http",
+      host: "10.0.1.168",
+      port: 2080,
+    });
+  });
+
+  it("rejects unknown schemes", () => {
+    expect(parseProxyUrl("ftp://proxy:21", "X", false)).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(parseProxyUrl("", "X", false)).toBeNull();
+    expect(parseProxyUrl("not a url", "X", false)).toBeNull();
+  });
+
+  it("rejects invalid ports", () => {
+    expect(parseProxyUrl("http://proxy:99999", "X", false)).toBeNull();
+  });
+});
+
+describe("resolveProxyFromEnv", () => {
+  it("prefers PANOS_PROXY over standard vars and marks it forced", () => {
+    const p = resolveProxyFromEnv({
+      PANOS_PROXY: "socks5h://10.0.1.168:2080",
+      HTTPS_PROXY: "http://other:3128",
+    });
+    expect(p?.source).toBe("PANOS_PROXY");
+    expect(p?.forced).toBe(true);
+    expect(p?.scheme).toBe("socks5h");
+  });
+
+  it("falls back to HTTPS_PROXY, then HTTP_PROXY, then ALL_PROXY", () => {
+    expect(resolveProxyFromEnv({ HTTPS_PROXY: "http://h:1" })?.source).toBe("HTTPS_PROXY");
+    expect(resolveProxyFromEnv({ HTTP_PROXY: "http://h:1" })?.source).toBe("HTTP_PROXY");
+    expect(resolveProxyFromEnv({ ALL_PROXY: "socks5://h:1" })?.source).toBe("ALL_PROXY");
+  });
+
+  it("honors lowercase variants", () => {
+    expect(resolveProxyFromEnv({ https_proxy: "http://h:1" })?.source).toBe("https_proxy");
+  });
+
+  it("returns null when no env var is set", () => {
+    expect(resolveProxyFromEnv({})).toBeNull();
+  });
+
+  it("ignores whitespace-only values", () => {
+    expect(resolveProxyFromEnv({ HTTPS_PROXY: "   " })).toBeNull();
+  });
+
+  it("marks non-PANOS_PROXY sources as non-forced", () => {
+    expect(resolveProxyFromEnv({ HTTPS_PROXY: "http://h:1" })?.forced).toBe(false);
+  });
+});
+
+describe("shouldBypassProxy", () => {
+  it("matches exact hostname", () => {
+    expect(shouldBypassProxy("example.com", "example.com")).toBe(true);
+  });
+
+  it("matches suffix with leading dot", () => {
+    expect(shouldBypassProxy("api.example.com", ".example.com")).toBe(true);
+  });
+
+  it("matches suffix without leading dot", () => {
+    expect(shouldBypassProxy("api.example.com", "example.com")).toBe(true);
+  });
+
+  it("does not match partial tokens", () => {
+    expect(shouldBypassProxy("notexample.com", "example.com")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(shouldBypassProxy("API.Example.COM", "example.com")).toBe(true);
+  });
+
+  it("supports comma-separated list", () => {
+    expect(shouldBypassProxy("foo.internal", "localhost, .internal , 10.0.0.0/8")).toBe(true);
+  });
+
+  it("wildcard bypasses everything", () => {
+    expect(shouldBypassProxy("any.host.com", "*")).toBe(true);
+  });
+
+  it("returns false for empty NO_PROXY", () => {
+    expect(shouldBypassProxy("example.com", undefined)).toBe(false);
+    expect(shouldBypassProxy("example.com", "")).toBe(false);
+  });
+});
+
+describe("describeProxy", () => {
+  it("formats with masked credentials", () => {
+    expect(
+      describeProxy({ PANOS_PROXY: "socks5h://alice:secret@10.0.1.168:2080" })
+    ).toBe("socks5h://alice:***@10.0.1.168:2080 (from PANOS_PROXY)");
+  });
+
+  it("formats without creds when none present", () => {
+    expect(describeProxy({ HTTPS_PROXY: "http://proxy:3128" })).toBe(
+      "http://proxy:3128 (from HTTPS_PROXY)"
+    );
+  });
+
+  it("returns null when no proxy configured", () => {
+    expect(describeProxy({})).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #7.

## Summary

- Add `src/api/proxy.ts` that resolves an active proxy from env vars and returns an appropriate `undici` `Dispatcher` per request.
- Replace the hardcoded `new Agent({ connect: { rejectUnauthorized: false } })` in `src/api/client.ts` with `buildDispatcher(url)`.
- Add `socks` (^2.8.3) as a runtime dependency for SOCKS4/5 support (undici has no native SOCKS).
- Document the new behavior under a "Proxy support" section in the README.

## Behavior

Resolution order (first non-empty wins):

1. `PANOS_PROXY` — explicit override; ignores `NO_PROXY`.
2. `HTTPS_PROXY` / `https_proxy`
3. `HTTP_PROXY` / `http_proxy`
4. `ALL_PROXY` / `all_proxy`

`NO_PROXY` is parsed for exact match, suffix match (leading dot optional), and `*` wildcard. Case-insensitive, comma-separated.

Supported URL schemes with optional `user:pass@`:

- `http://` / `https://` — undici `ProxyAgent` with `rejectUnauthorized: false` on both `proxyTls` and `requestTls`, so the existing self-signed-cert behavior is preserved through a CONNECT tunnel.
- `socks5://` / `socks5h://` — SOCKS5 via `socks` package. `socks5h` is the usual choice when the firewall hostname only resolves on the far side of the proxy (management VRF, internal DNS).
- `socks4://` / `socks4a://` — included for completeness.

For `https:` targets over SOCKS, TLS is wrapped manually on the tunneled socket via `tls.connect({ socket, servername, rejectUnauthorized: false, ALPNProtocols: ["http/1.1"] })`.

## Why not just the built-in `EnvHttpProxyAgent`?

Two reasons:

1. Undici's env-aware proxy agent only handles HTTP(S) proxies. SOCKS is the common case here (management access almost always goes through SSH tunnels or SOCKS5).
2. The existing code passes an explicit `dispatcher` per `fetch` call and relies on `rejectUnauthorized: false` for self-signed PanOS certs. A global `setGlobalDispatcher(new EnvHttpProxyAgent())` would lose that.

A per-request `buildDispatcher(url)` keeps the existing contract and adds SOCKS as a peer.

## Tests

24 new unit tests in `tests/api/proxy.test.ts`, all green (109 total):

- `parseProxyUrl`: scheme parsing, default ports, creds, bare `host:port`, invalid input
- `resolveProxyFromEnv`: precedence, `PANOS_PROXY` forced flag, lowercase variants, whitespace
- `shouldBypassProxy`: exact, suffix, leading-dot suffix, wildcard, case folding, comma lists
- `describeProxy`: credential masking in diagnostic output

## Manual verification

Confirmed end-to-end against a real PA-5400 behind a SOCKS5 tunnel:

```
SOCKS5 tunnel OK, starting TLS...
TLS OK in 811ms, cipher: ECDHE-RSA-AES256-SHA
HTTP/1.1 400 Missing value for parameter "user".
```

(400 is expected — that was a `keygen` without credentials. The point is the connection succeeded through `PANOS_PROXY=socks5h://...` with proxy-side DNS resolution.)

## Backwards compatibility

With no proxy env vars set, `buildDispatcher` returns the same `new Agent({ connect: { rejectUnauthorized: false } })` the code has always used. No behavior change for existing users.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 109/109 passing
- [x] Manual: `PANOS_PROXY=socks5h://...` end-to-end against real firewall
- [x] Manual: no proxy env vars — direct connection still works