### PR TITLE
feat: surface active proxy in startup log and connection errors

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import { XMLParser } from "fast-xml-parser";
 import { fetch } from "undici";
 import { resolveFirewall, isMultiFirewall } from "../config/firewalls.js";
-import { buildDispatcher } from "./proxy.js";
+import { buildDispatcher, describeProxy } from "./proxy.js";
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -52,7 +52,9 @@ function connectError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
   const cause = error instanceof Error && error.cause;
   const causeStr = cause instanceof Error ? cause.message : cause ? String(cause) : null;
-  return `Error connecting to firewall: ${msg}${causeStr ? ` (${causeStr})` : ""}`;
+  const proxy = describeProxy();
+  const proxyStr = proxy ? ` [via ${proxy}]` : "";
+  return `Error connecting to firewall: ${msg}${causeStr ? ` (${causeStr})` : ""}${proxyStr}`;
 }
 
 async function makeRequest(url: string): Promise<ApiResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { loadFirewallConfig } from "./config/firewalls.js";
+import { describeProxy } from "./api/proxy.js";
 
 import { registerFirewallTools } from "./tools/firewalls.js";
 import { registerSystemTools } from "./tools/system.js";
@@ -46,6 +47,10 @@ registerUtilityTools(server);
 
 async function main() {
   await loadFirewallConfig();
+  const proxy = describeProxy();
+  if (proxy) {
+    console.error(`PanOS proxy: ${proxy}`);
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }


### PR DESCRIPTION
Follow-up to #8 — wires `describeProxy()` into the production paths so the active proxy is visible to operators.

## Summary

- `src/index.ts` — log the active proxy on server start (stderr, masked credentials), e.g.
  ```
  PanOS proxy: socks5h://alice:***@10.0.1.168:2080 (from PANOS_PROXY)
  ```
  When no proxy is configured, nothing is logged.

- `src/api/client.ts` — append `[via <proxy>]` to connection error messages from `connectError()`, so failures clearly show which proxy was attempted, e.g.
  ```
  Error connecting to firewall: fetch failed (connect ECONNREFUSED 10.0.1.168:2080) [via socks5h://10.0.1.168:2080 (from PANOS_PROXY)]
  ```

## Why

`describeProxy()` was introduced in #8, exported and unit-tested, but never called from production code. Without this, when a proxy is misconfigured the user gets a bare network error with no indication that a proxy was even involved.

stderr is used for the startup log because stdout is reserved for the MCP stdio protocol — same convention as `src/cli/keygen.ts`.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 109/109 passing (no test changes needed; `describeProxy` is already covered)
- [ ] Manual: start server with `PANOS_PROXY=socks5h://...` and confirm the line appears on stderr
- [ ] Manual: hit a firewall through a broken proxy and confirm the error message includes `[via ...]`
