### PR TITLE
Add URL Filter Log Access tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports **PA-Series firewalls** (PA-220, PA-415, PA-440, PA-445, PA-450, PA-460
 
 > **Warning:** This server gives an AI model direct access to your firewall configuration via the PanOS API. AI models can make mistakes, misinterpret instructions, or take unintended actions that may disrupt network traffic, modify security policies, or cause outages. **Use at your own risk.** Always review AI-proposed changes before committing, use a read-only API key where possible, and never run against production firewalls without understanding the consequences.
 
-**116 tools across 16 modules** covering firewall management, monitoring, and configuration changes — all from within your AI assistant.
+**117 tools across 16 modules** covering firewall management, monitoring, and configuration changes — all from within your AI assistant.
 
 ## What you can do
 
@@ -146,7 +146,7 @@ When multiple entries are configured, every tool accepts a `firewall: <name>` pa
 | Admin | 3 | Admins, roles, auth profiles |
 | VPN | 3 | IPSec tunnels, GlobalProtect users and config |
 | Panorama | 29 | Device groups, templates, shared objects, pre/post rules CRUD, DG NAT rules CRUD, push status, HA |
-| Logs | 4 | Traffic, threat, system, and config logs |
+| Logs | 5 | Traffic, threat, system, URL, and config logs |
 | Threat | 4 | WildFire, antivirus, content versions, URL categories |
 | Certificates | 7 | Certificates, decryption rules (get, add, move, delete, enable/disable) and profiles |
 | Licenses | 2 | License info and usage |

--- a/manifest.json
+++ b/manifest.json
@@ -88,6 +88,7 @@
     { "name": "get_threat_logs", "description": "Retrieves recent threat logs" },
     { "name": "get_system_logs", "description": "Retrieves recent system logs" },
     { "name": "get_config_logs", "description": "Retrieves recent configuration change logs" },
+    { "name": "get_url_filter_logs", "description": "Retrieves recent URL filter logs" },
     { "name": "get_wildfire_status", "description": "Retrieves WildFire cloud connection status" },
     { "name": "get_antivirus_version", "description": "Retrieves antivirus and threat signature versions" },
     { "name": "get_content_versions", "description": "Retrieves available content update versions" },

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -70,4 +70,21 @@ export function registerLogsTools(server: McpServer) {
       return formatResponse(result);
     }
   );
+
+  server.tool(
+    "get_url_filter_logs",
+    "[READ-ONLY] Retrieves recent URL filtering logs from the firewall using the PanOS log API (type=log&log-type=url). Shows URLs visited and actions taken (allow/block/continue/override) by URL filtering policy.",
+    {
+      nlogs: nlogsSchema,
+      query: logQuery.describe("Filter query (e.g., '( action eq block )' or '( category eq malware )')"),
+      firewall: firewallName,
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async ({ nlogs, query, firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const result = await executeLogQuery("url", nlogs || 20, query, target);
+      return formatResponse(result);
+    }
+  );
 }


### PR DESCRIPTION
### Summary

- Add tool to read URL filter logs from PANOS
- Update documentation to mention new tool
- Include new tool in manifest.json


### Test Plan

- [x] Validate tools return appropriate data, including URLs, categories, etc. 
- [x] Spot check documentation for changes