### PR TITLE
chore: bump version to 1.3.17

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": "0.3",
   "name": "panos-mcp",
-  "version": "1.3.16",
-  "description": "Control Palo Alto Networks PA-Series firewalls and Panorama with AI. 116 tools across 16 modules: security policies, NAT, objects, VPN, logs, WildFire, GlobalProtect, decryption, and more. Supports staged commits and read-only inspection. For multi-firewall setups use the CLI mode — see github.com/apius-tech/Palo-MCP.",
+  "version": "1.3.17",
+  "description": "Control Palo Alto Networks PA-Series firewalls and Panorama with AI. 117 tools across 16 modules: security policies, NAT, objects, VPN, logs, WildFire, GlobalProtect, decryption, and more. Supports staged commits and read-only inspection. For multi-firewall setups use the CLI mode — see github.com/apius-tech/Palo-MCP.",
   "author": { "name": "Apius Technologies SA" },
   "repository": { "type": "git", "url": "https://github.com/apius-tech/Palo-MCP" },
   "privacy_policies": ["https://github.com/apius-tech/Palo-MCP#privacy", "https://github.com/apius-tech/Palo-MCP#security"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panos-mcp",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panos-mcp",
-      "version": "1.3.16",
+      "version": "1.3.17",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panos-mcp",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "MCP server for Palo Alto Networks PanOS firewalls",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { registerUtilityTools } from "./tools/utility.js";
 
 const server = new McpServer({
   name: "panos-mcp",
-  version: "1.3.16",
+  version: "1.3.17",
 });
 
 // Register all tools


### PR DESCRIPTION
## Summary

Bumps version from `1.3.16` to `1.3.17` to match the upcoming v1.3.17 release covering the `get_url_filter_logs` tool added in #11.

Updated:
- `package.json`
- `package-lock.json`
- `manifest.json` (version + tool count `116` → `117` in description)
- `src/index.ts` (MCP server version)

## Test plan

- [ ] `npm run build` succeeds
- [ ] Server reports `1.3.17` on startup
- [ ] Manifest version matches release tag

---
_Generated by [Claude Code](https://claude.ai/code/session_01791KwemGfZ46QKx6Ju5jkP)_