### PR TITLE
[codex] Add 1Password secret injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Talk to your firewall in plain English. Some examples:
 - **Configuration management** via XPath-based set/delete with staged commits
 - **Panorama support** for centralized management of device groups, templates, and shared objects
 - **Multi-firewall mode** — manage multiple PA-Series devices or Panorama instances simultaneously
-- **Secure credential storage** — API keys stored in the OS keychain, never in plaintext
+- **Secure credential options** — API keys can be injected from 1Password Environments or stored in the OS keychain, avoiding plaintext when secure storage is available
 - **Input validation** with Zod schemas for early error detection
 - **Safety labels** on every tool: `[READ-ONLY]`, `[MODIFIES CONFIG]`, or `[ADVANCED]`
 
@@ -50,13 +50,20 @@ Talk to your firewall in plain English. Some examples:
 
 1. Download the latest `panos-mcp.mcpb` from [Releases](https://github.com/apius-tech/Palo-MCP/releases)
 2. Double-click the file — Claude Desktop opens an install dialog
-3. Enter your **Firewall Host** and **API Key** when prompted
+3. Enter one complete credential pair: either your **1Password Environment ID** and **1Password Service Account Token**, or your **Firewall Host** and **API Key**
 
-The API key is stored securely in your OS keychain, not in plaintext config files.
+When using 1Password, create an Environment containing `PANOS_HOST` and `PANOS_API_KEY`. The service account token is marked sensitive in the Desktop Extension config.
 
 ### Claude Desktop — npx (single or multiple firewalls)
 
-Add to your `claude_desktop_config.json`:
+Create a 1Password Environment containing:
+
+```text
+PANOS_HOST=your-firewall-or-panorama
+PANOS_API_KEY=your-api-key
+```
+
+Then add the Environment ID and service account token to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -65,8 +72,8 @@ Add to your `claude_desktop_config.json`:
       "command": "npx",
       "args": ["-y", "github:apius-tech/Palo-MCP"],
       "env": {
-        "PANOS_HOST": "your-firewall-or-panorama",
-        "PANOS_API_KEY": "your-api-key"
+        "OP_ENVIRONMENT_ID": "your-1password-environment-id",
+        "OP_SERVICE_ACCOUNT_TOKEN": "your-1password-service-account-token"
       }
     }
   }
@@ -75,12 +82,14 @@ Add to your `claude_desktop_config.json`:
 
 Config file location: **macOS** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows** `%APPDATA%\Claude\claude_desktop_config.json`
 
+If you are not using 1Password, you can still set `PANOS_HOST` and `PANOS_API_KEY` directly in the MCP server environment.
+
 ### Claude Code (CLI)
 
 ```bash
 claude mcp add panos -- npx -y github:apius-tech/Palo-MCP \
-  --env PANOS_HOST=your-firewall-or-panorama \
-  --env PANOS_API_KEY=your-api-key
+  --env OP_ENVIRONMENT_ID=your-1password-environment-id \
+  --env OP_SERVICE_ACCOUNT_TOKEN=your-1password-service-account-token
 ```
 
 ### Cursor
@@ -94,15 +103,15 @@ Open Cursor Settings (Ctrl+Shift+J) → MCP → Add new MCP server, or add to `~
       "command": "npx",
       "args": ["-y", "github:apius-tech/Palo-MCP"],
       "env": {
-        "PANOS_HOST": "your-firewall-or-panorama",
-        "PANOS_API_KEY": "your-api-key"
+        "OP_ENVIRONMENT_ID": "your-1password-environment-id",
+        "OP_SERVICE_ACCOUNT_TOKEN": "your-1password-service-account-token"
       }
     }
   }
 }
 ```
 
-Replace `your-firewall-or-panorama` with your firewall/Panorama IP or hostname, and `your-api-key` with your PanOS API key.
+Replace `your-1password-environment-id` with the Environment ID copied from 1Password, and `your-1password-service-account-token` with a service account token that can read that Environment.
 
 ## Multiple firewalls
 
@@ -115,6 +124,21 @@ npx panos-keygen --host panorama.example.com  --user admin --name panorama
 ```
 
 You will be prompted for the password. The API key is stored in the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) — never in the JSON file.
+
+To use 1Password Environments with multiple firewalls, create one Environment variable per firewall API key, then reference the variable name with `api_key_env`:
+
+```json
+{
+  "firewalls": [
+    { "name": "hq-fw", "host": "fw-hq.example.com", "api_key_env": "PANOS_HQ_FW_API_KEY" },
+    { "name": "panorama", "host": "panorama.example.com", "api_key_env": "PANOS_PANORAMA_API_KEY" }
+  ]
+}
+```
+
+Start the server with `OP_ENVIRONMENT_ID` and `OP_SERVICE_ACCOUNT_TOKEN`; the named API key variables are loaded at startup and kept in memory only.
+
+Keep the 1Password Environment scoped to PanOS-MCP values. The server retains only `PANOS_HOST`, `PANOS_API_KEY`, `PANOS_VERIFY_SSL`, and variable names referenced by `api_key_env`.
 
 If you already have API keys, you can write them directly to `firewalls.json` with `api_key` fields — they will be auto-migrated to the keychain on the next server startup:
 
@@ -129,7 +153,7 @@ If you already have API keys, you can write them directly to `firewalls.json` wi
 
 Override the config path with `PANOS_FIREWALLS_CONFIG=/custom/path.json` if needed. `name` is the identifier you pass to tools (max 63 chars); `host` may include or omit the `https://` prefix.
 
-When multiple entries are configured, every tool accepts a `firewall: <name>` parameter — required in multi-mode, optional when a single entry or `PANOS_HOST`/`PANOS_API_KEY` env vars are used. Ask the model to call `list_firewalls` to see which targets are configured.
+When multiple entries are configured, every tool accepts a `firewall: <name>` parameter — required in multi-mode, optional when a single entry or environment-sourced `PANOS_HOST`/`PANOS_API_KEY` pair is used. Ask the model to call `list_firewalls` to see which targets are configured.
 
 > **Linux headless servers:** If no keychain daemon is available (e.g. servers without `libsecret`), API keys fall back to plaintext in `firewalls.json` with a warning. Restrict the file with `chmod 600 ~/.config/panos-mcp/firewalls.json` in that case.
 
@@ -209,7 +233,7 @@ Self-signed firewall certificates are accepted through the proxy tunnel (the ser
 git clone https://github.com/apius-tech/Palo-MCP.git
 cd Palo-MCP
 npm install
-cp .env.example .env   # fill in PANOS_HOST and PANOS_API_KEY
+# Configure OP_ENVIRONMENT_ID/OP_SERVICE_ACCOUNT_TOKEN, or PANOS_HOST/PANOS_API_KEY
 ```
 
 ```bash

--- a/firewalls.json.example
+++ b/firewalls.json.example
@@ -3,12 +3,12 @@
     {
       "name": "hq-fw01",
       "host": "10.0.1.1",
-      "api_key": "LUFRPT..."
+      "api_key_env": "PANOS_HQ_FW01_API_KEY"
     },
     {
       "name": "branch-fw01",
       "host": "10.0.2.1",
-      "api_key": "LUFRPT..."
+      "api_key_env": "PANOS_BRANCH_FW01_API_KEY"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,9 @@
       "args": ["${__dirname}/server/index.cjs"],
       "env": {
         "PANOS_HOST": "${user_config.host}",
-        "PANOS_API_KEY": "${user_config.api_key}"
+        "PANOS_API_KEY": "${user_config.api_key}",
+        "OP_ENVIRONMENT_ID": "${user_config.op_environment_id}",
+        "OP_SERVICE_ACCOUNT_TOKEN": "${user_config.op_service_account_token}"
       }
     }
   },
@@ -142,15 +144,28 @@
     "host": {
       "type": "string",
       "title": "Firewall Host",
-      "description": "PanOS firewall or Panorama hostname or IP address",
-      "required": true
+      "description": "PanOS firewall or Panorama hostname or IP address. Provide with API Key, or leave blank when using a complete 1Password pair.",
+      "required": false
     },
     "api_key": {
       "type": "string",
       "title": "API Key",
-      "description": "PanOS API key",
+      "description": "PanOS API key. Provide with Firewall Host, or leave blank when using a complete 1Password pair.",
       "sensitive": true,
-      "required": true
+      "required": false
+    },
+    "op_environment_id": {
+      "type": "string",
+      "title": "1Password Environment ID",
+      "description": "1Password Environment containing PANOS_HOST and PANOS_API_KEY. Provide with a service account token.",
+      "required": false
+    },
+    "op_service_account_token": {
+      "type": "string",
+      "title": "1Password Service Account Token",
+      "description": "Service account token with access to the 1Password Environment. Provide with an Environment ID.",
+      "sensitive": true,
+      "required": false
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "panos-mcp",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panos-mcp",
-      "version": "1.3.19",
+      "version": "1.3.20",
       "license": "ISC",
       "dependencies": {
+        "@1password/sdk": "0.5.0-beta.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@napi-rs/keyring": "^1.2.0",
         "fast-xml-parser": "^5.9.3",
@@ -26,6 +27,21 @@
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@1password/sdk": {
+      "version": "0.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@1password/sdk/-/sdk-0.5.0-beta.1.tgz",
+      "integrity": "sha512-GY1kcn86qkb39jt20AyOftEu5Tw/Kyq4f84GOHXKRjur4TvqvzdhapynBBosRcBL+kBrc+E8cx7Tp7GEfqAomw==",
+      "license": "MIT",
+      "dependencies": {
+        "@1password/sdk-core": "0.5.0-beta.1"
+      }
+    },
+    "node_modules/@1password/sdk-core": {
+      "version": "0.5.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@1password/sdk-core/-/sdk-core-0.5.0-beta.1.tgz",
+      "integrity": "sha512-61Q2n0kKYXBVAbW5ZVFqtbK1KX3lUfFi8wdsv+UjIVtbFd+X1GpFbLFs+nPtPgX+Z7oc2tTN/czK0S9Cz4oF/A==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@1password/sdk": "0.5.0-beta.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/keyring": "^1.2.0",
     "fast-xml-parser": "^5.9.3",

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -1,4 +1,7 @@
 import { build } from "esbuild";
+import { copyFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
 
 await build({
   entryPoints: ["dist/index.js"],
@@ -9,5 +12,12 @@ await build({
   target: "node18",
   external: ["@napi-rs/keyring"],
 });
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+mkdirSync("extension/server", { recursive: true });
+copyFileSync(
+  `${root}/node_modules/@1password/sdk-core/nodejs/core_bg.wasm`,
+  "extension/server/core_bg.wasm"
+);
 
 console.log("Bundle created: extension/server/index.cjs");

--- a/scripts/pack-extension.js
+++ b/scripts/pack-extension.js
@@ -6,11 +6,36 @@ cpSync("manifest.json", "extension/manifest.json");
 cpSync("icon.png", "extension/icon.png");
 cpSync("LICENSE", "extension/LICENSE");
 
-// Create .mcpb zip from extension/ contents (no shell — cwd handles the directory)
-const result = spawnSync("zip", ["-r", "../panos-mcp.mcpb", "manifest.json", "icon.png", "LICENSE", "server/index.cjs"], {
-  cwd: "extension",
-  stdio: "inherit",
-});
+const files = ["manifest.json", "icon.png", "LICENSE", "server/index.cjs", "server/core_bg.wasm"];
+rmSync("panos-mcp.mcpb", { force: true });
+
+function packWithZip() {
+  return spawnSync("zip", ["-r", "../panos-mcp.mcpb", ...files], {
+    cwd: "extension",
+    stdio: "inherit",
+  });
+}
+
+function packWithPowerShell() {
+  const literalPaths = ["manifest.json", "icon.png", "LICENSE", "server"]
+    .map((file) => `'${file.replace(/'/g, "''")}'`)
+    .join(", ");
+  const command = [
+    "$dest = Join-Path (Get-Location).Path '..\\panos-mcp.mcpb'",
+    `Compress-Archive -LiteralPath ${literalPaths} -DestinationPath $dest -Force`,
+  ].join("; ");
+
+  return spawnSync("powershell.exe", ["-NoProfile", "-Command", command], {
+    cwd: "extension",
+    stdio: "inherit",
+  });
+}
+
+// Create .mcpb zip from extension/ contents (cwd handles the directory)
+let result = packWithZip();
+if (result.error && result.error.code === "ENOENT" && process.platform === "win32") {
+  result = packWithPowerShell();
+}
 if (result.status !== 0) process.exit(result.status ?? 1);
 
 // Clean up the extension directory

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,7 +38,7 @@ export function resolveTarget(firewallParam?: string): FirewallTarget | ApiRespo
     }
     return {
       success: false,
-      error: "No firewall configured. Set PANOS_HOST/PANOS_API_KEY environment variables or provide a firewalls.json config file.",
+      error: "No firewall configured. Set PANOS_HOST/PANOS_API_KEY directly, load them from 1Password with OP_ENVIRONMENT_ID/OP_SERVICE_ACCOUNT_TOKEN, or provide a firewalls.json config file.",
     };
   }
 

--- a/src/config/firewalls.ts
+++ b/src/config/firewalls.ts
@@ -15,6 +15,7 @@ const firewallFileEntrySchema = z.object({
   name: z.string().min(1).max(63),
   host: z.string().min(1),
   api_key: z.string().optional(),
+  api_key_env: z.string().min(1).optional(),
   verify_ssl: z.boolean().optional(),
 });
 
@@ -28,11 +29,63 @@ function sanitizeHost(host: string): string {
 
 let entries: Array<{ name: string; host: string; verify_ssl: boolean }> = [];
 const keyMap = new Map<string, string>();
+const injectedEnvironment = new Map<string, string>();
 
 const defaultConfigPath = join(homedir(), ".config", "panos-mcp", "firewalls.json");
 
 export function getConfigPath(): string {
   return process.env.PANOS_FIREWALLS_CONFIG ?? defaultConfigPath;
+}
+
+export function getExpectedEnvironmentVariableNames(): Set<string> {
+  const names = new Set(["PANOS_HOST", "PANOS_API_KEY", "PANOS_VERIFY_SSL"]);
+  let raw: string;
+  try {
+    raw = readFileSync(getConfigPath(), "utf-8");
+  } catch {
+    return names;
+  }
+
+  const parsed = firewallConfigSchema.parse(JSON.parse(raw));
+  for (const entry of parsed.firewalls) {
+    if (entry.api_key_env) names.add(entry.api_key_env);
+  }
+
+  return names;
+}
+
+export function setInjectedEnvironment(env: ReadonlyMap<string, string>): void {
+  injectedEnvironment.clear();
+  for (const [name, value] of env) {
+    injectedEnvironment.set(name, value);
+  }
+}
+
+function readConfiguredEnv(name: string): string {
+  const injected = injectedEnvironment.get(name);
+  if (injected !== undefined) return injected.trim();
+  return (process.env[name] ?? "").trim();
+}
+
+function parseBooleanEnv(value: string): boolean | null {
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return null;
+}
+
+function fileEntryWithoutPlaintextKey(entry: {
+  name: string;
+  host: string;
+  api_key_env?: string;
+  verify_ssl: boolean;
+}): { name: string; host: string; api_key_env?: string; verify_ssl?: boolean } {
+  return {
+    name: entry.name,
+    host: entry.host,
+    ...(entry.api_key_env ? { api_key_env: entry.api_key_env } : {}),
+    ...(entry.verify_ssl ? { verify_ssl: entry.verify_ssl } : {}),
+  };
 }
 
 export async function loadFirewallConfig(): Promise<void> {
@@ -55,6 +108,7 @@ export async function loadFirewallConfig(): Promise<void> {
     name: e.name,
     host: sanitizeHost(e.host),
     api_key: e.api_key,
+    api_key_env: e.api_key_env,
     verify_ssl: e.verify_ssl ?? false,
   }));
 
@@ -66,7 +120,7 @@ export async function loadFirewallConfig(): Promise<void> {
         for (const e of toMigrate) {
           await setKey(e.name, e.api_key!);
         }
-        const cleaned = { firewalls: fileEntries.map(({ name, host }) => ({ name, host })) };
+        const cleaned = { firewalls: fileEntries.map(fileEntryWithoutPlaintextKey) };
         writeFileSync(configPath, JSON.stringify(cleaned, null, 2) + "\n");
         process.stderr.write(
           `[panos-mcp] Migrated ${toMigrate.length} API key(s) to system keychain\n`
@@ -83,8 +137,20 @@ export async function loadFirewallConfig(): Promise<void> {
 
   // Load keys into memory
   for (const e of entries) {
+    const fileEntry = fileEntries.find((f) => f.name === e.name);
+    if (fileEntry?.api_key_env) {
+      const key = readConfiguredEnv(fileEntry.api_key_env);
+      if (key) {
+        keyMap.set(e.name, key);
+      } else {
+        process.stderr.write(
+          `[panos-mcp] WARNING: Environment variable "${fileEntry.api_key_env}" for firewall "${e.name}" is not set — it will be unavailable\n`
+        );
+      }
+      continue;
+    }
+
     if (isKeychainAvailable()) {
-      const fileEntry = fileEntries.find((f) => f.name === e.name);
       const key = (await getKey(e.name)) ?? fileEntry?.api_key ?? null;
       if (key) {
         keyMap.set(e.name, key);
@@ -120,9 +186,10 @@ export function resolveFirewall(name?: string): FirewallEntry | null {
   if (entries.length > 1) return null;
 
   // No config entries — fall back to env vars
-  const host = sanitizeHost(process.env.PANOS_HOST ?? "");
-  const api_key = (process.env.PANOS_API_KEY ?? "").trim();
-  if (host && api_key) return { name: "env", host, api_key, verify_ssl: false };
+  const host = sanitizeHost(readConfiguredEnv("PANOS_HOST"));
+  const api_key = readConfiguredEnv("PANOS_API_KEY");
+  const verify_ssl = parseBooleanEnv(readConfiguredEnv("PANOS_VERIFY_SSL")) ?? false;
+  if (host && api_key) return { name: "env", host, api_key, verify_ssl };
 
   return null;
 }
@@ -137,7 +204,7 @@ export function getFirewallEntries(): Array<{ name: string; host: string; verify
 
 export async function saveFirewallEntry(entry: FirewallEntry): Promise<void> {
   await initKeychain();
-  entry = { ...entry, host: sanitizeHost(entry.host) };
+  entry = { ...entry, host: sanitizeHost(entry.host), verify_ssl: entry.verify_ssl ?? false };
   const configPath = getConfigPath();
   mkdirSync(dirname(configPath), { recursive: true });
 

--- a/src/config/onepassword.ts
+++ b/src/config/onepassword.ts
@@ -1,0 +1,92 @@
+type EnvLike = Record<string, string | undefined>;
+type OnePasswordClientConfiguration = {
+  auth: string;
+  integrationName: string;
+  integrationVersion: string;
+};
+type CreateClient = (config: OnePasswordClientConfiguration) => Promise<OnePasswordClient>;
+type LoadSdk = () => Promise<{ createClient: CreateClient }>;
+
+interface OnePasswordEnvironmentVariable {
+  name: string;
+  value: string;
+}
+
+interface OnePasswordEnvironmentResponse {
+  variables: OnePasswordEnvironmentVariable[];
+}
+
+interface OnePasswordClient {
+  environments: {
+    getVariables(environmentId: string): Promise<OnePasswordEnvironmentResponse>;
+  };
+}
+
+export interface LoadOnePasswordEnvironmentOptions {
+  env?: EnvLike;
+  createClientImpl?: CreateClient;
+  loadSdkImpl?: LoadSdk;
+  allowedNames?: ReadonlySet<string>;
+}
+
+function readEnv(env: EnvLike, name: string): string {
+  const value = (env[name] ?? "").trim();
+  if (/^\$\{user_config\.[A-Za-z0-9_]+\}$/.test(value)) return "";
+  return value;
+}
+
+function redact(message: string, secrets: string[]): string {
+  let redacted = message;
+  for (const secret of secrets) {
+    if (secret) redacted = redacted.split(secret).join("[REDACTED]");
+  }
+  return redacted;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function loadOnePasswordEnvironment(
+  options: LoadOnePasswordEnvironmentOptions = {}
+): Promise<Map<string, string>> {
+  const env = options.env ?? process.env;
+  const environmentId = readEnv(env, "OP_ENVIRONMENT_ID");
+  const serviceAccountToken = readEnv(env, "OP_SERVICE_ACCOUNT_TOKEN");
+
+  if (!environmentId && !serviceAccountToken) return new Map();
+  if (!environmentId) {
+    throw new Error("OP_ENVIRONMENT_ID is required when OP_SERVICE_ACCOUNT_TOKEN is set");
+  }
+  if (!serviceAccountToken) {
+    throw new Error("OP_SERVICE_ACCOUNT_TOKEN is required when OP_ENVIRONMENT_ID is set");
+  }
+
+  const createClientImpl =
+    options.createClientImpl ??
+    (await (options.loadSdkImpl ?? (async () => import("@1password/sdk")))()).createClient;
+
+  try {
+    const client = (await createClientImpl({
+      auth: serviceAccountToken,
+      integrationName: "panos-mcp",
+      integrationVersion: process.env.npm_package_version ?? "unknown",
+    })) as OnePasswordClient;
+    const response = await client.environments.getVariables(environmentId);
+    const variables = new Map<string, string>();
+
+    for (const variable of response.variables ?? []) {
+      if (options.allowedNames && !options.allowedNames.has(variable.name)) continue;
+      if (variable.name) variables.set(variable.name, variable.value ?? "");
+    }
+
+    return variables;
+  } catch (error) {
+    throw new Error(
+      `[panos-mcp] Failed to load 1Password Environment: ${redact(
+        errorMessage(error),
+        [serviceAccountToken]
+      )}`
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,13 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadFirewallConfig } from "./config/firewalls.js";
+import {
+  getExpectedEnvironmentVariableNames,
+  loadFirewallConfig,
+  setInjectedEnvironment,
+} from "./config/firewalls.js";
 import { isKeychainAvailable } from "./config/keychain.js";
+import { loadOnePasswordEnvironment } from "./config/onepassword.js";
 import { describeProxy } from "./api/proxy.js";
 
 import { registerFirewallTools } from "./tools/firewalls.js";
@@ -64,6 +69,16 @@ registerConfigTools(server);
 registerUtilityTools(server);
 
 async function main() {
+  const onePasswordEnvironment = await loadOnePasswordEnvironment({
+    allowedNames: getExpectedEnvironmentVariableNames(),
+  });
+  setInjectedEnvironment(onePasswordEnvironment);
+  if (onePasswordEnvironment.size > 0) {
+    process.stderr.write(
+      `[panos-mcp] Loaded ${onePasswordEnvironment.size} environment variable(s) from 1Password Environment\n`
+    );
+  }
+
   await loadFirewallConfig();
   if (!isKeychainAvailable()) {
     process.stderr.write(
@@ -80,4 +95,7 @@ async function main() {
   await server.connect(transport);
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/tools/firewalls.ts
+++ b/src/tools/firewalls.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getFirewallEntries, isMultiFirewall } from "../config/firewalls.js";
+import { getFirewallEntries, isMultiFirewall, resolveFirewall } from "../config/firewalls.js";
 
 export function registerFirewallTools(server: McpServer) {
   server.tool(
@@ -29,9 +29,9 @@ export function registerFirewallTools(server: McpServer) {
       };
 
       if (entries.length === 0) {
-        const host = process.env.PANOS_HOST;
-        if (host) {
-          data.firewalls = [{ name: "env", host }];
+        const envFirewall = resolveFirewall();
+        if (envFirewall) {
+          data.firewalls = [{ name: envFirewall.name, host: envFirewall.host }];
         }
       }
 

--- a/tests/config/firewalls.test.ts
+++ b/tests/config/firewalls.test.ts
@@ -16,7 +16,9 @@ import {
   resolveFirewall,
   isMultiFirewall,
   getFirewallEntries,
+  getExpectedEnvironmentVariableNames,
   saveFirewallEntry,
+  setInjectedEnvironment,
 } from "../../src/config/firewalls.js";
 
 const tmpConfig = resolve("firewalls.test.tmp.json");
@@ -42,6 +44,8 @@ describe("firewalls config", () => {
     delete process.env.PANOS_FIREWALLS_CONFIG;
     delete process.env.PANOS_HOST;
     delete process.env.PANOS_API_KEY;
+    delete process.env.PANOS_VERIFY_SSL;
+    setInjectedEnvironment(new Map());
   });
 
   describe("no config file — env var fallback", () => {
@@ -57,7 +61,26 @@ describe("firewalls config", () => {
     it("resolves to env entry when env vars are set", () => {
       process.env.PANOS_HOST = "10.0.0.1";
       process.env.PANOS_API_KEY = "key123";
-      expect(resolveFirewall()).toEqual({ name: "env", host: "10.0.0.1", api_key: "key123" });
+      expect(resolveFirewall()).toEqual({ name: "env", host: "10.0.0.1", api_key: "key123", verify_ssl: false });
+    });
+
+    it("prefers injected 1Password values over process env values", () => {
+      process.env.PANOS_HOST = "plain-fw.example.com";
+      process.env.PANOS_API_KEY = "plain-key";
+      setInjectedEnvironment(
+        new Map([
+          ["PANOS_HOST", "https://op-fw.example.com/"],
+          ["PANOS_API_KEY", "op-key"],
+          ["PANOS_VERIFY_SSL", "true"],
+        ])
+      );
+
+      expect(resolveFirewall()).toEqual({
+        name: "env",
+        host: "op-fw.example.com",
+        api_key: "op-key",
+        verify_ssl: true,
+      });
     });
 
     it("isMultiFirewall returns false", () => {
@@ -78,11 +101,11 @@ describe("firewalls config", () => {
     });
 
     it("resolves without name (defaults to single entry)", () => {
-      expect(resolveFirewall()).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1" });
+      expect(resolveFirewall()).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1", verify_ssl: false });
     });
 
     it("resolves by name", () => {
-      expect(resolveFirewall("fw1")).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1" });
+      expect(resolveFirewall("fw1")).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1", verify_ssl: false });
     });
 
     it("returns null for unknown name", () => {
@@ -113,7 +136,7 @@ describe("firewalls config", () => {
     });
 
     it("resolves by name", () => {
-      expect(resolveFirewall("fw2")).toEqual({ name: "fw2", host: "10.0.2.2", api_key: "key2" });
+      expect(resolveFirewall("fw2")).toEqual({ name: "fw2", host: "10.0.2.2", api_key: "key2", verify_ssl: false });
     });
 
     it("returns null for unknown name", () => {
@@ -128,6 +151,72 @@ describe("firewalls config", () => {
       expect(getFirewallEntries()).toHaveLength(2);
     });
   });
+
+  describe("api_key_env entries", () => {
+    beforeEach(() => {
+      process.env.PANOS_FIREWALLS_CONFIG = tmpConfig;
+    });
+
+    it("loads an entry API key from injected 1Password variables", async () => {
+      setInjectedEnvironment(new Map([["HQ_FW_API_KEY", "op-hq-key"]]));
+      writeConfig({
+        firewalls: [{ name: "fw1", host: "10.0.1.1", api_key_env: "HQ_FW_API_KEY" }],
+      });
+
+      await loadFirewallConfig();
+
+      expect(resolveFirewall("fw1")).toEqual({
+        name: "fw1",
+        host: "10.0.1.1",
+        api_key: "op-hq-key",
+        verify_ssl: false,
+      });
+      expect(vi.mocked(getKey)).not.toHaveBeenCalledWith("fw1");
+    });
+
+    it("does not fall back to keychain when an explicit api_key_env is missing", async () => {
+      keychainStore.set("fw1", "keychain-key");
+      writeConfig({
+        firewalls: [{ name: "fw1", host: "10.0.1.1", api_key_env: "MISSING_FW_API_KEY" }],
+      });
+
+      await loadFirewallConfig();
+
+      expect(resolveFirewall("fw1")).toBeNull();
+    });
+  });
+
+  describe("getExpectedEnvironmentVariableNames", () => {
+    beforeEach(() => {
+      process.env.PANOS_FIREWALLS_CONFIG = tmpConfig;
+    });
+
+    it("includes single-firewall PANOS env vars without a config file", () => {
+      expect(getExpectedEnvironmentVariableNames()).toEqual(
+        new Set(["PANOS_HOST", "PANOS_API_KEY", "PANOS_VERIFY_SSL"])
+      );
+    });
+
+    it("includes api_key_env names from firewalls.json", () => {
+      writeConfig({
+        firewalls: [
+          { name: "fw1", host: "10.0.1.1", api_key_env: "HQ_FW_API_KEY" },
+          { name: "fw2", host: "10.0.2.2", api_key_env: "BRANCH_FW_API_KEY" },
+        ],
+      });
+
+      expect(getExpectedEnvironmentVariableNames()).toEqual(
+        new Set([
+          "PANOS_HOST",
+          "PANOS_API_KEY",
+          "PANOS_VERIFY_SSL",
+          "HQ_FW_API_KEY",
+          "BRANCH_FW_API_KEY",
+        ])
+      );
+    });
+  });
+
 
   describe("migration — plaintext api_key in JSON", () => {
     beforeEach(() => {
@@ -163,6 +252,7 @@ describe("firewalls config", () => {
         name: "fw1",
         host: "10.0.1.1",
         api_key: "migrated-key",
+        verify_ssl: false,
       });
     });
 
@@ -197,6 +287,7 @@ describe("firewalls config", () => {
         name: "fw1",
         host: "10.0.1.1",
         api_key: "plaintext-key",
+        verify_ssl: false,
       });
     });
 
@@ -262,7 +353,7 @@ describe("firewalls config", () => {
 
       expect(getFirewallEntries()).toHaveLength(1);
       expect(getFirewallEntries()[0].name).toBe("fw1");
-      expect(resolveFirewall("fw1")).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1" });
+      expect(resolveFirewall("fw1")).toEqual({ name: "fw1", host: "10.0.1.1", api_key: "key1", verify_ssl: false });
     });
   });
 });

--- a/tests/config/onepassword.test.ts
+++ b/tests/config/onepassword.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadOnePasswordEnvironment } from "../../src/config/onepassword.js";
+
+describe("onepassword environment loader", () => {
+  it("returns an empty map when 1Password is not configured", async () => {
+    const createClient = vi.fn();
+
+    const variables = await loadOnePasswordEnvironment({
+      env: {},
+      createClientImpl: createClient as any,
+    });
+
+    expect(variables.size).toBe(0);
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it("does not load the SDK when 1Password is not configured", async () => {
+    const loadSdk = vi.fn();
+
+    const variables = await loadOnePasswordEnvironment({
+      env: {},
+      loadSdkImpl: loadSdk as any,
+    });
+
+    expect(variables.size).toBe(0);
+    expect(loadSdk).not.toHaveBeenCalled();
+  });
+
+  it("treats unresolved Desktop Extension placeholders as unset", async () => {
+    const loadSdk = vi.fn();
+
+    const variables = await loadOnePasswordEnvironment({
+      env: {
+        OP_ENVIRONMENT_ID: "${user_config.op_environment_id}",
+        OP_SERVICE_ACCOUNT_TOKEN: "${user_config.op_service_account_token}",
+      },
+      loadSdkImpl: loadSdk as any,
+    });
+
+    expect(variables.size).toBe(0);
+    expect(loadSdk).not.toHaveBeenCalled();
+  });
+
+  it("throws when only OP_ENVIRONMENT_ID is set", async () => {
+    await expect(
+      loadOnePasswordEnvironment({
+        env: { OP_ENVIRONMENT_ID: "env-id" },
+        createClientImpl: vi.fn() as any,
+      })
+    ).rejects.toThrow("OP_SERVICE_ACCOUNT_TOKEN");
+  });
+
+  it("throws when only OP_SERVICE_ACCOUNT_TOKEN is set", async () => {
+    await expect(
+      loadOnePasswordEnvironment({
+        env: { OP_SERVICE_ACCOUNT_TOKEN: "ops_token" },
+        createClientImpl: vi.fn() as any,
+      })
+    ).rejects.toThrow("OP_ENVIRONMENT_ID");
+  });
+
+  it("loads variables from the configured 1Password Environment", async () => {
+    const getVariables = vi.fn().mockResolvedValue({
+      variables: [
+        { name: "PANOS_HOST", value: "fw.example.com", masked: false },
+        { name: "PANOS_API_KEY", value: "secret-key", masked: true },
+      ],
+    });
+    const createClient = vi.fn().mockResolvedValue({ environments: { getVariables } });
+
+    const variables = await loadOnePasswordEnvironment({
+      env: {
+        OP_ENVIRONMENT_ID: "env-id",
+        OP_SERVICE_ACCOUNT_TOKEN: "ops_secret_token",
+      },
+      createClientImpl: createClient as any,
+    });
+
+    expect(createClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: "ops_secret_token",
+        integrationName: "panos-mcp",
+      })
+    );
+    expect(getVariables).toHaveBeenCalledWith("env-id");
+    expect(variables).toEqual(
+      new Map([
+        ["PANOS_HOST", "fw.example.com"],
+        ["PANOS_API_KEY", "secret-key"],
+      ])
+    );
+  });
+
+  it("keeps only allowed variable names when a filter is provided", async () => {
+    const getVariables = vi.fn().mockResolvedValue({
+      variables: [
+        { name: "PANOS_API_KEY", value: "secret-key", masked: true },
+        { name: "UNRELATED_SECRET", value: "do-not-retain", masked: true },
+      ],
+    });
+    const createClient = vi.fn().mockResolvedValue({ environments: { getVariables } });
+
+    const variables = await loadOnePasswordEnvironment({
+      env: {
+        OP_ENVIRONMENT_ID: "env-id",
+        OP_SERVICE_ACCOUNT_TOKEN: "ops_secret_token",
+      },
+      allowedNames: new Set(["PANOS_API_KEY"]),
+      createClientImpl: createClient as any,
+    });
+
+    expect(variables).toEqual(new Map([["PANOS_API_KEY", "secret-key"]]));
+  });
+
+
+  it("redacts the service account token from SDK errors", async () => {
+    const createClient = vi.fn().mockRejectedValue(new Error("bad token ops_secret_token"));
+
+    await expect(
+      loadOnePasswordEnvironment({
+        env: {
+          OP_ENVIRONMENT_ID: "env-id",
+          OP_SERVICE_ACCOUNT_TOKEN: "ops_secret_token",
+        },
+        createClientImpl: createClient as any,
+      })
+    ).rejects.toThrow("[REDACTED]");
+
+    await expect(
+      loadOnePasswordEnvironment({
+        env: {
+          OP_ENVIRONMENT_ID: "env-id",
+          OP_SERVICE_ACCOUNT_TOKEN: "ops_secret_token",
+        },
+        createClientImpl: createClient as any,
+      })
+    ).rejects.not.toThrow("ops_secret_token");
+  });
+});


### PR DESCRIPTION
## Summary
- Add native 1Password Environment loading via `OP_ENVIRONMENT_ID` and `OP_SERVICE_ACCOUNT_TOKEN` without copying loaded secrets wholesale into `process.env`.
- Support single-firewall injection through `PANOS_HOST` / `PANOS_API_KEY` and multi-firewall `api_key_env` entries in `firewalls.json`.
- Update Desktop Extension packaging to include the 1Password SDK WASM core and document the new setup path.

## Security and compatibility notes
- The 1Password SDK is loaded lazily only when 1Password configuration is present, preserving direct env var, keychain, and plaintext fallback paths.
- 1Password Environment values are filtered to the PanOS variables needed by the current config: `PANOS_HOST`, `PANOS_API_KEY`, `PANOS_VERIFY_SSL`, and configured `api_key_env` names.
- Desktop Extension config now supports either a direct host/API key pair or a 1Password Environment ID/service account token pair.

## Verification
- `npm run build`
- `npm test` (122 tests passing)
- `npm run pack:extension`
- Verified `panos-mcp.mcpb` contains `server/index.cjs` and `server/core_bg.wasm`

## Follow-up
- `npm audit` still reports existing dependency advisories, including a critical Vitest advisory; this PR does not change the test toolchain beyond adding the 1Password SDK dependency.