### PR TITLE
docs: correct MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PanOS MCP Server
 
-[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/apius-tech/Palo-MCP)](https://github.com/apius-tech/Palo-MCP/stargazers)
 [![Tests](https://img.shields.io/badge/tests-85%20passing-brightgreen)](https://github.com/apius-tech/Palo-MCP/actions)
 [![GitHub release](https://img.shields.io/github/v/release/apius-tech/Palo-MCP)](https://github.com/apius-tech/Palo-MCP/releases/latest)


### PR DESCRIPTION
## Summary

- update the README license badge from ISC to MIT
- point the badge at the MIT license page

## Why

The project was relicensed to MIT, and both `LICENSE` and `package.json` identify MIT, but the README badge still advertised ISC.

## Impact

Documentation-only change. The README now consistently reflects the project's current license.

## Validation

- `git diff --check`
