### PR TITLE
ci(dependabot): group security updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         applies-to: version-updates
         dependency-type: "development"
         update-types: ["minor", "patch"]
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- Adds a `security-updates` group to `.github/dependabot.yml`, alongside the existing `production-minor-patch` / `development-minor-patch` groups
- Root cause of #29/#30/#31 all failing CI: those were security-triggered PRs (out-of-band vulnerability alerts), which weren't covered by the existing groups — those only apply to scheduled `version-updates`. Each vulnerable transitive dep got its own PR, and since `npm audit --omit=dev` checks the whole tree, no single PR could pass while the others' fixes were still missing.
- Going forward, Dependabot will bundle compatible security fixes into one PR instead of N separate red ones.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Config-only change, no code touched — CI test suite still expected green