### PR TITLE
feat: NCP LocalMCP server mode with NetOps tool enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,13 @@
-PANOS_HOST=192.168.1.1
-PANOS_API_KEY=your-api-key-here
+PANOS_HOST=https://firewall.example
+PANOS_API_KEY=
+PANOS_USERNAME=
+PANOS_PASSWORD=
+PANOS_VSYS=vsys1
+# Default true in Aviz LocalMCP; set false only for lab self-signed certs
+PANOS_VERIFY_TLS=true
+MCP_TRANSPORT=sse
+MCP_BIND_HOST=0.0.0.0
+MCP_PORT=8001
+# Optional: when set, require Authorization: Bearer <token>
+MCP_API_TOKEN=
+LOCAL_MCP_MODE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Aviz NCP LocalMCP image for the Palo-MCP fork.
+# Build with a NON-lab tag so the running demo (v1.7.0 Python POC) is untouched:
+#   docker build -t aviz/ncp-paloalto-mcp:community-dev .
+#
+# Do NOT retag over aviz/ncp-paloalto-mcp:v1.7.0 until lab cutover (Step 6).
+
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+# Skip lifecycle scripts; compile explicitly.
+RUN npm ci --ignore-scripts && npm run build
+
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --ignore-scripts \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/dist ./dist
+COPY scripts/start-localmcp.sh ./scripts/start-localmcp.sh
+RUN chmod +x ./scripts/start-localmcp.sh
+
+ENV LOCAL_MCP_MODE=true \
+    MCP_TRANSPORT=sse \
+    MCP_BIND_HOST=0.0.0.0 \
+    MCP_PORT=8001 \
+    MCP_SERVER_PORT=8001 \
+    PANOS_VERIFY_TLS=true \
+    PANOS_VSYS=vsys1 \
+    NODE_ENV=production
+
+EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:8001/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["sh", "scripts/start-localmcp.sh"]

--- a/README.md
+++ b/README.md
@@ -1,271 +1,96 @@
-# PanOS MCP Server
+# NCP Palo Alto MCP
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![GitHub stars](https://img.shields.io/github/stars/apius-tech/Palo-MCP)](https://github.com/apius-tech/Palo-MCP/stargazers)
-[![Tests](https://img.shields.io/badge/tests-109%20passing-brightgreen)](https://github.com/apius-tech/Palo-MCP/actions)
-[![GitHub release](https://img.shields.io/github/v/release/apius-tech/Palo-MCP)](https://github.com/apius-tech/Palo-MCP/releases/latest)
+Aviz Networks fork of [apius-tech/Palo-MCP](https://github.com/apius-tech/Palo-MCP) for use as an
+NCP **Local MCP** connector (same pattern as `nexus-dashboard-mcp`).
 
-**Control your Palo Alto Networks firewall with AI.** PanOS MCP is an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that connects AI assistants — Claude, Cursor, and others — directly to PAN-OS firewalls and Panorama via the PAN-OS XML API. Ask questions, inspect policies, and make configuration changes in plain English instead of navigating the GUI or writing API scripts.
+## Why this repo
 
-Supports **PA-Series firewalls** (PA-220, PA-415, PA-440, PA-445, PA-450, PA-460, PA-1400, PA-3400, PA-5400, PA-7500 and more), **VM-Series**, **CN-Series**, and **Panorama** — any device running PAN-OS with API access enabled.
+- **Upstream:** community PAN-OS MCP (pinned; do not float on `main`)
+- **NCP:** package as `aviz/ncp-paloalto-mcp` and start via Local MCP tab
+- **NetOps surface:** agent allowlist of useful tools only — not all 117 tools
+- **Gaps:** custom XML wrappers for interface counters, rule hit counts,
+  labeled CPU/RAM, environmentals, and NTP (see `docs/NETOPS_TOOL_PLAN.md`)
 
-> **Warning:** This server gives an AI model direct access to your firewall configuration via the PanOS API. AI models can make mistakes, misinterpret instructions, or take unintended actions that may disrupt network traffic, modify security policies, or cause outages. **Use at your own risk.** Always review AI-proposed changes before committing, use a read-only API key where possible, and never run against production firewalls without understanding the consequences.
+## Upstream pin
 
-**117 tools across 16 modules** covering firewall management, monitoring, and configuration changes — all from within your AI assistant.
-
-## What you can do
-
-Talk to your firewall in plain English. Some examples:
-
-- *"Show me all security rules that allow traffic from the internet to the DMZ"*
-- *"Which GlobalProtect users are currently connected?"*
-- *"Create an address object for 10.10.0.0/24 called corp-network and add it to the allow-internal group"*
-- *"Check HA status — is the standby firewall in sync?"*
-- *"Show me the last 50 threat log entries"*
-- *"Move the block-social-media rule above the allow-web rule and commit"*
-- *"List all IPSec tunnels and their current state"*
-- *"What software version is running on each managed device in Panorama?"*
-
-## Features
-
-- **Read-only inspection** of firewall state, policies, objects, logs, and more
-- **Configuration management** via XPath-based set/delete with staged commits
-- **Panorama support** for centralized management of device groups, templates, and shared objects
-- **Multi-firewall mode** — manage multiple PA-Series devices or Panorama instances simultaneously
-- **Secure credential storage** — API keys stored in the OS keychain, never in plaintext
-- **Input validation** with Zod schemas for early error detection
-- **Safety labels** on every tool: `[READ-ONLY]`, `[MODIFIES CONFIG]`, or `[ADVANCED]`
-
-## Prerequisites
-
-- Node.js 22.19+
-- A PanOS firewall or Panorama appliance with API access enabled
-- A PanOS API key ([how to generate](https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key))
-
-To generate a PanOS API key directly from a firewall, use the XML API keygen endpoint:
+| Field | Value |
+| --- | --- |
+| Upstream | https://github.com/apius-tech/Palo-MCP |
+| Version | 1.3.29 |
+| Commit | `4c2cea57677ee2a204e01eff8705229c14b2134b` |
 
 ```bash
-curl -k -X GET 'https://<FIREWALL_IP_OR_HOST>/api/?type=keygen&user=<USERNAME>&password=<PASSWORD>'
+git fetch upstream
+git log -1 upstream/main   # or a release tag
 ```
 
-This sends credentials in the request URL and skips TLS certificate verification. Use it only from a trusted management network, and prefer a scoped or read-only API key where possible.
+## LocalMCP
 
-## Quick Start
+Endpoints expected by ncp-api:
 
-> **Single firewall vs. multi-firewall:** The Desktop Extension supports **one firewall** configured at install time. For managing multiple firewalls or Panorama instances simultaneously, use the npx or Claude Code CLI installation with the `panos-keygen` setup described in [Multiple firewalls](#multiple-firewalls).
+| Path | Method | Purpose |
+| --- | --- | --- |
+| `/mcp/sse` | GET | MCP SSE stream |
+| `/mcp/messages?sessionId=…` | POST | JSON-RPC messages |
+| `/health` | GET | Container health |
 
-### Claude Desktop — Desktop Extension (single firewall)
+Env vars match what ncp-api injects for Palo Alto LocalMCP
+(`PANOS_HOST`, `PANOS_API_KEY` or username/password, `PANOS_VERIFY_TLS`,
+`MCP_API_TOKEN`, `MCP_TRANSPORT=sse`, port `8001`).
 
-1. Download the latest `panos-mcp.mcpb` from [Releases](https://github.com/apius-tech/Palo-MCP/releases)
-2. Double-click the file — Claude Desktop opens an install dialog
-3. Enter your **Firewall Host** and **API Key** when prompted
+**TLS:** `PANOS_VERIFY_TLS` defaults to `true` in this fork. Lab self-signed
+firewalls should set `false` explicitly (ncp-api already passes connector
+`verify_ssl`).
 
-The API key is stored securely in your OS keychain, not in plaintext config files.
+### Image
 
-### Claude Desktop — npx (single or multiple firewalls)
-
-Add to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "panos": {
-      "command": "npx",
-      "args": ["-y", "github:apius-tech/Palo-MCP"],
-      "env": {
-        "PANOS_HOST": "your-firewall-or-panorama",
-        "PANOS_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
-Config file location: **macOS** `~/Library/Application Support/Claude/claude_desktop_config.json` · **Windows** `%APPDATA%\Claude\claude_desktop_config.json`
-
-### Claude Code (CLI)
+ncp-api starts `aviz/ncp-paloalto-mcp:${PALOALTO_MCP_IMAGE_TAG}` (default
+`community-dev`). This is **not** `DATA_CONNECTORS_IMAGE_TAG` — the Kafka
+API collector stays on `aviz/ncp-firewall-collector:<shared-tag>`.
 
 ```bash
-claude mcp add panos -- npx -y github:apius-tech/Palo-MCP \
-  --env PANOS_HOST=your-firewall-or-panorama \
-  --env PANOS_API_KEY=your-api-key
+docker build -t aviz/ncp-paloalto-mcp:community-dev .
 ```
 
-### Cursor
+Do **not** retag over `:v1.7.0` / `:v1.8.0` (those were the retired Python POC).
 
-Open Cursor Settings (Ctrl+Shift+J) → MCP → Add new MCP server, or add to `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "panos": {
-      "command": "npx",
-      "args": ["-y", "github:apius-tech/Palo-MCP"],
-      "env": {
-        "PANOS_HOST": "your-firewall-or-panorama",
-        "PANOS_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
-Replace `your-firewall-or-panorama` with your firewall/Panorama IP or hostname, and `your-api-key` with your PanOS API key.
-
-## Multiple firewalls
-
-For managing more than one firewall or Panorama, use the `panos-keygen` CLI to register each one. It generates an API key, stores it in your OS keychain, and writes the host entry to `~/.config/panos-mcp/firewalls.json`:
+Local stdio (unchanged upstream behavior):
 
 ```bash
-npx panos-keygen --host fw-hq.example.com     --user admin --name hq-fw
-npx panos-keygen --host fw-branch.example.com --user admin --name branch-fw
-npx panos-keygen --host panorama.example.com  --user admin --name panorama
+npm ci && npm start
 ```
 
-You will be prompted for the password. The API key is stored in the OS keychain (macOS Keychain, Windows Credential Manager, Linux Secret Service) — never in the JSON file.
+## Agent
 
-If you already have API keys, you can write them directly to `firewalls.json` with `api_key` fields — they will be auto-migrated to the keychain on the next server startup:
-
-```json
-{
-  "firewalls": [
-    { "name": "hq-fw",  "host": "fw-hq.example.com",  "api_key": "LUFRPT1..." },
-    { "name": "panorama", "host": "panorama.example.com", "api_key": "LUFRPT2..." }
-  ]
-}
-```
-
-Override the config path with `PANOS_FIREWALLS_CONFIG=/custom/path.json` if needed. `name` is the identifier you pass to tools (max 63 chars); `host` may include or omit the `https://` prefix.
-
-When multiple entries are configured, every tool accepts a `firewall: <name>` parameter — required in multi-mode, optional when a single entry or `PANOS_HOST`/`PANOS_API_KEY` env vars are used. Ask the model to call `list_firewalls` to see which targets are configured.
-
-> **Linux headless servers:** If no keychain daemon is available (e.g. servers without `libsecret`), API keys fall back to plaintext in `firewalls.json` with a warning. Restrict the file with `chmod 600 ~/.config/panos-mcp/firewalls.json` in that case.
-
-## Tool Categories
-
-| Category | Tools | Description |
-|----------|-------|-------------|
-| System | 4 | Firewall info, HA status, sessions, resources |
-| Network | 10 | Interfaces, zones, routing, ARP, VLANs, DHCP, DNS proxy, static routes (get, add, delete) |
-| Security | 18 | Security rules CRUD, profiles, profile groups, PBF rules CRUD, DoS, QoS rules CRUD |
-| Objects | 16 | Address/service objects and groups (get, add, delete), application filters, tags (get, add, delete) |
-| NAT | 5 | NAT rules (get, add, move, delete, enable/disable) |
-| User-ID | 3 | User-IP mappings, groups, config |
-| Admin | 3 | Admins, roles, auth profiles |
-| VPN | 3 | IPSec tunnels, GlobalProtect users and config |
-| Panorama | 29 | Device groups, templates, shared objects, pre/post rules CRUD, DG NAT rules CRUD, push status, HA |
-| Logs | 5 | Traffic, threat, system, URL, and config logs |
-| Threat | 4 | WildFire, antivirus, content versions, URL categories |
-| Certificates | 7 | Certificates, decryption rules (get, add, move, delete, enable/disable) and profiles |
-| Licenses | 2 | License info and usage |
-| Config | 5 | Set/delete config, commit, Panorama commit, Panorama push |
-| Utility | 2 | Arbitrary op commands, XPath config reads |
-| Firewalls | 1 | List configured firewall targets |
-
-## Safety Labels
-
-Every tool is labeled to indicate its impact:
-
-- **`[READ-ONLY]`** — Only reads data; no changes to the firewall
-- **`[MODIFIES CONFIG]`** — Stages or commits configuration changes that affect live traffic
-- **`[ADVANCED]`** — Accepts arbitrary commands; impact depends on the input
-
-## API Key
-
-Generate a PanOS API key from the firewall web UI or CLI:
-
-**Web UI:** Device → Administrators → your admin user → Generate API Key
-
-**CLI:**
-```bash
-curl -k 'https://YOUR-FIREWALL/api/?type=keygen&user=admin&password=YOUR-PASSWORD'
-```
-
-See [PanOS documentation](https://docs.paloaltonetworks.com/pan-os/11-1/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key) for details.
-
-## Proxy support
-
-If your firewall is reachable only via a proxy (management network behind a jump host, remote access via SOCKS5, corporate HTTP proxy), set one of the following environment variables before starting the server:
-
-| Variable | Purpose |
-|---|---|
-| `PANOS_PROXY` | **Explicit override.** Used regardless of `NO_PROXY`. Recommended for MCP deployments. |
-| `HTTPS_PROXY` / `https_proxy` | Standard — same semantics as most HTTP clients. |
-| `HTTP_PROXY` / `http_proxy` | Fallback. |
-| `ALL_PROXY` / `all_proxy` | Fallback (common for SOCKS). |
-| `NO_PROXY` / `no_proxy` | Comma-separated list of hostnames/suffixes to bypass. `*` disables proxying entirely. Ignored when `PANOS_PROXY` is set. |
-
-Supported URL schemes:
-
-- `http://[user:pass@]host:port` — HTTP CONNECT proxy
-- `https://[user:pass@]host:port` — HTTPS CONNECT proxy
-- `socks5://[user:pass@]host:port` — SOCKS5, **client-side** DNS
-- `socks5h://[user:pass@]host:port` — SOCKS5, **proxy-side** DNS (use this when the firewall hostname only resolves on the far side of the proxy)
-- `socks4://[user@]host:port` / `socks4a://[user@]host:port`
-
-Example — SOCKS5 with remote DNS:
+Custom agent package: `ncp-sdk-agent/` (`panos-mcp-agent` 0.2.0).
+Allowlist is community tool names plus Aviz wrappers. Writes are
+`add_security_rule` and `commit` with agent-side confirm-before-call.
 
 ```bash
-export PANOS_PROXY=socks5h://10.0.1.168:2080
+ncp validate ncp-sdk-agent
+ncp pack ncp-sdk-agent
+ncp onboard ncp-sdk-agent
 ```
 
-Self-signed firewall certificates are accepted through the proxy tunnel (the server already disables cert validation for the PanOS target).
+Chat with `/panos-mcp-agent` on a project that has the Palo Alto Local MCP
+connector assigned.
 
-## Development
+## Status
 
-```bash
-git clone https://github.com/apius-tech/Palo-MCP.git
-cd Palo-MCP
-npm install
-cp .env.example .env   # fill in PANOS_HOST and PANOS_API_KEY
-```
+- **Step 1 (done):** tool coverage map → `docs/NETOPS_TOOL_PLAN.md`
+- **Step 2 (done):** LocalMCP SSE entrypoint + Dockerfile + TLS defaults
+- **Step 3 (done):** ncp-api uses `PALOALTO_MCP_IMAGE_TAG` (not the POC image)
+- **Step 4 (done):** agent allowlist + confirm-before-write
+- **Step 5 (done):** custom gap wrappers in this fork
+- **Step 6:** lab chat validation
 
-```bash
-npm run build           # compile TypeScript
-npm run dev             # watch mode (rebuild on changes)
-npm test                # run tests
-npm run start           # run the server
-npm run pack:extension  # build Desktop Extension (.mcpb)
-```
+## Not in scope (for now)
 
-## Examples
-
-**"Show me the firewall system info"**
-
-Uses `get_firewall_info` to retrieve hostname, model, serial number, and software version.
-
-**"List all security rules on the firewall"**
-
-Uses `get_security_rules` to retrieve the full security policy rulebase.
-
-**"Create an address object for the 10.0.1.0/24 subnet called lab-network, then commit"**
-
-Uses `set_config` to create the address object in the candidate configuration, then `commit` to activate the change on the running firewall.
-
-## Privacy
-
-- **No data collection** — This extension does not collect, store, or transmit any data to third parties.
-- **Direct communication only** — All API calls go directly from your machine to your PanOS firewall or Panorama. No traffic is routed through intermediary servers.
-- **Local credential storage** — API keys are stored in your OS keychain (Desktop Extension and multi-firewall mode via `panos-keygen`), or in local environment variables. They are never sent anywhere other than your firewall.
-- **No telemetry or analytics** — This extension contains no tracking, telemetry, or analytics of any kind.
-- **Data retention** — No data is retained by the extension or its authors. Firewall responses exist only transiently in memory to serve the active request and are not persisted, logged, or shared. The only data stored at rest is your API key, kept locally in your OS keychain or environment variables under your control.
-- **Third-party sharing** — None. No data is shared with the authors, Anthropic, or any third party beyond the direct connection to your own firewall.
-- **Contact** — For privacy questions or data requests, [open a GitHub issue](https://github.com/apius-tech/Palo-MCP/issues). Maintained by Apius Technologies SA.
-
-## Disclaimer
-
-This software is provided "as is", without warranty of any kind. This tool connects an AI model to live network infrastructure. AI models can hallucinate, misunderstand context, and execute unintended changes. The authors are not responsible for any damage, data loss, outages, or security incidents caused by the use of this software. You are solely responsible for any actions taken by the AI model through this server.
-
-**Recommendations:**
-- Test in a lab environment before using in production
-- Use a read-only API key for inspection tasks
-- Always review and confirm changes before committing
-- Monitor firewall logs for unexpected configuration changes
-
-## Security
-
-Please **do not** open a public GitHub issue for security vulnerabilities. See [SECURITY.md](SECURITY.md) for private reporting via GitHub Private Vulnerability Reporting or email.
+- Panorama tools
+- Shipping all write/delete/`run_op_command` tools to chat
+- Replacing the Kafka API collector path
 
 ## License
 
-MIT
+MIT (same as upstream Palo-MCP). Upstream README preserved at
+`docs/UPSTREAM_README.md`.

--- a/docs/NETOPS_TOOL_PLAN.md
+++ b/docs/NETOPS_TOOL_PLAN.md
@@ -1,0 +1,71 @@
+# NetOps tool plan (Step 1)
+
+Pinned upstream: **apius-tech/Palo-MCP** `1.3.29` @ `4c2cea5`.
+
+Goal: same NetOps coverage as the lab demo, via community tools + a few
+custom wrappers. Chat gets an **allowlist**, not the full 117-tool catalog.
+No Panorama.
+
+## Coverage vs current Aviz demo tools
+
+| Our demo tool | Community tool | Source |
+| --- | --- | --- |
+| `get_firewall_info` | `get_firewall_info` | Community |
+| `get_ha_status` | `get_ha_status` | Community |
+| `get_active_sessions` | `get_active_sessions` | Community |
+| `get_system_resources` | `get_system_resources` (raw `top`) | **Custom wrapper** (labeled CPU/RAM/`pan_task`) |
+| `get_interfaces` | `get_interfaces` | Community |
+| `get_interface_counters` | — | **Custom wrapper** |
+| `get_zones` | `get_zones` | Community |
+| `get_routing_table` | `get_routing_table` | Community |
+| `get_security_rules` | `get_security_rules` | Community |
+| `get_nat_rules` | `get_nat_rules` | Community |
+| `get_rule_hit_counts` | — | **Custom wrapper** |
+| `get_address_objects` | `get_address_objects` | Community |
+| `get_service_objects` | `get_service_objects` | Community |
+| `get_traffic_logs` | `get_traffic_logs` | Community |
+| `get_threat_logs` | `get_threat_logs` | Community |
+| `get_environmentals` | — | **Custom wrapper** |
+| `get_licenses` | `get_licenses` | Community |
+| `get_content_versions` | `get_content_versions` | Community |
+| `get_ntp_and_clock` | — | **Custom wrapper** |
+| `get_system_logs` | `get_system_logs` | Community |
+| `get_config_logs` | `get_config_logs` | Community |
+| `create_security_rule` | `add_security_rule` | Community + **agent confirm** |
+| `commit_firewall_config` | `commit` | Community + **agent confirm** |
+
+## Chat allowlist
+
+Community reads + wrappers + two writes (`add_security_rule`, `commit`).
+See `ncp-sdk-agent/ncp.toml`.
+
+## Custom wrappers (in this fork)
+
+Registered by `src/tools/netopsWrappers.ts`; `get_system_resources` is
+parsed in-place by `src/parse/systemResources.ts`.
+
+| Wrapper | PAN-OS call | Why |
+| --- | --- | --- |
+| Labeled system resources | `show system resources` + parse | Community returns unstructured `top` |
+| Interface counters | `show counter interface all` | Missing upstream |
+| Rule hit counts | `show rule-hit-count ...` | Missing upstream |
+| Environmentals | `show system environmentals` | Missing upstream |
+| NTP + clock | `show clock` + `show ntp` | Missing upstream |
+
+## Explicitly not allowlisted
+
+- All `panorama_*` tools
+- `delete_*`, `set_config`, `delete_config`, `run_op_command`
+- Broad object/VPN/admin write tools until product asks for them
+
+## Confirm-before-write
+
+Upstream `add_security_rule` / `commit` have **no** confirmation token.
+Until we add server-side guards in this fork, the **agent** must:
+
+1. Preview / explain the change
+2. Wait for explicit user yes
+3. Only then call the write tool
+4. Keep commit as a separate confirmed step
+
+Prefer creating rules **disabled** unless the user asks otherwise.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "panos-mcp",
+  "name": "ncp-paloalto-mcp",
   "version": "1.3.29",
-  "description": "MCP server for Palo Alto Networks PanOS firewalls",
+  "description": "Aviz NCP Local MCP fork of Palo-MCP (PAN-OS) \u2014 pinned upstream + NetOps wrappers",
   "type": "module",
   "engines": {
     "node": ">=22.19.0"
@@ -15,6 +15,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
+    "start:localmcp": "LOCAL_MCP_MODE=true MCP_TRANSPORT=sse node dist/index.js",
     "keygen": "node dist/cli/keygen.js",
     "test": "vitest run",
     "bundle": "node scripts/bundle.js",
@@ -43,5 +44,6 @@
     "esbuild": "^0.28.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
-  }
+  },
+  "upstreamVersion": "1.3.29"
 }

--- a/scripts/start-localmcp.sh
+++ b/scripts/start-localmcp.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# NCP LocalMCP entrypoint. SSE on :8001 for aviz-shared-network.
+# Does not touch the Kafka API collector path.
+set -eu
+
+export LOCAL_MCP_MODE="${LOCAL_MCP_MODE:-true}"
+export MCP_TRANSPORT="${MCP_TRANSPORT:-sse}"
+export MCP_BIND_HOST="${MCP_BIND_HOST:-0.0.0.0}"
+export MCP_PORT="${MCP_PORT:-${MCP_SERVER_PORT:-8001}}"
+export MCP_SERVER_PORT="${MCP_SERVER_PORT:-8001}"
+
+echo "LocalMCP: starting ncp-paloalto-mcp on ${MCP_BIND_HOST}:${MCP_PORT} (${MCP_TRANSPORT})"
+exec node /app/dist/index.js

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,6 +2,7 @@ import { XMLParser } from "fast-xml-parser";
 import { fetch } from "undici";
 import { resolveFirewall, isMultiFirewall } from "../config/firewalls.js";
 import { buildDispatcher, describeProxy } from "./proxy.js";
+import { extractJobId, buildLogTimeQuery, normalizeLogResults } from "../parse/logResults.js";
 
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
@@ -102,11 +103,17 @@ async function makeRequest(url: string, apiKey = "", verifySSL = false): Promise
   };
 }
 
-export async function generateApiKey(host: string, username: string, password: string): Promise<ApiResponse> {
-  const url = `https://${host}/api/?type=keygen&user=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`;
+export async function generateApiKey(
+  host: string,
+  username: string,
+  password: string,
+  verifySSL = false
+): Promise<ApiResponse> {
+  const sanitized = host.replace(/^https?:\/\//, "").replace(/\/+$/, "").trim();
+  const url = `https://${sanitized}/api/?type=keygen&user=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`;
 
   try {
-    const result = await makeRequest(url);
+    const result = await makeRequest(url, "", verifySSL);
     if (result.success && result.data?.key) {
       return { success: true, data: { key: result.data.key } };
     }
@@ -142,12 +149,16 @@ export async function executeLogQuery(
   logType: string,
   nlogs: number,
   query: string | undefined,
-  target: FirewallTarget
+  target: FirewallTarget,
+  hours?: number
 ): Promise<ApiResponse> {
+  const effectiveQuery =
+    hours != null ? buildLogTimeQuery(hours, query) : query;
+
   // Step 1: Submit log query (type=log)
   let url = `https://${target.host}/api/?type=log&log-type=${encodeURIComponent(logType)}&nlogs=${nlogs}`;
-  if (query) {
-    url += `&query=${encodeURIComponent(query)}`;
+  if (effectiveQuery) {
+    url += `&query=${encodeURIComponent(effectiveQuery)}`;
   }
 
   let submitResult: ApiResponse;
@@ -162,7 +173,7 @@ export async function executeLogQuery(
 
   if (!submitResult.success) return submitResult;
 
-  const jobId = submitResult.data?.job;
+  const jobId = extractJobId(submitResult.data?.job);
   if (!jobId) {
     return { success: false, error: "No job ID returned from log query" };
   }
@@ -189,7 +200,16 @@ export async function executeLogQuery(
 
     const status = pollResult.data?.job?.status || pollResult.data?.log?.logs?.["@_progress"];
     if (status === "FIN" || pollResult.data?.log?.logs?.["@_progress"] === "100") {
-      return { success: true, data: pollResult.data?.log?.logs };
+      const normalized = normalizeLogResults(pollResult.data?.log?.logs);
+      return {
+        success: true,
+        data: {
+          ...normalized,
+          job: pollResult.data?.job ?? null,
+          query: effectiveQuery ?? null,
+          log_type: logType,
+        },
+      };
     }
   }
 

--- a/src/config/firewalls.ts
+++ b/src/config/firewalls.ts
@@ -26,6 +26,57 @@ function sanitizeHost(host: string): string {
   return host.replace(/^https?:\/\//, "").replace(/\/+$/, "").trim();
 }
 
+function parseEnvBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value.trim() === "") return defaultValue;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+/** Runtime-only firewall (NCP LocalMCP env); does not write firewalls.json. */
+export function setRuntimeFirewall(entry: FirewallEntry): void {
+  const host = sanitizeHost(entry.host);
+  entries = [{ name: entry.name, host, verify_ssl: entry.verify_ssl }];
+  keyMap.clear();
+  keyMap.set(entry.name, entry.api_key);
+}
+
+/**
+ * Seed a single firewall from NCP container env (PANOS_*).
+ * Prefer API key; otherwise keygen with username/password.
+ * TLS verify defaults to true (lab can set PANOS_VERIFY_TLS=false).
+ */
+export async function ensureNcpEnvFirewall(): Promise<void> {
+  if (entries.length > 0) return;
+
+  const host = sanitizeHost(process.env.PANOS_HOST ?? "");
+  if (!host) return;
+
+  const verify_ssl = parseEnvBool(process.env.PANOS_VERIFY_TLS, true);
+  let api_key = (process.env.PANOS_API_KEY ?? "").trim();
+
+  if (!api_key) {
+    const username = (process.env.PANOS_USERNAME ?? "").trim();
+    const password = process.env.PANOS_PASSWORD ?? "";
+    if (username && password) {
+      const { generateApiKey } = await import("../api/client.js");
+      const result = await generateApiKey(host, username, password, verify_ssl);
+      if (!result.success || !result.data?.key) {
+        throw new Error(
+          `PAN-OS keygen failed: ${result.error || "no key returned"}`
+        );
+      }
+      api_key = String(result.data.key);
+      process.stderr.write("[ncp-paloalto-mcp] Generated API key from PANOS_USERNAME/PASSWORD\n");
+    }
+  }
+
+  if (!api_key) return;
+
+  setRuntimeFirewall({ name: "env", host, api_key, verify_ssl });
+  process.stderr.write(
+    `[ncp-paloalto-mcp] Using firewall env host=${host} verify_ssl=${verify_ssl}\n`
+  );
+}
+
 let entries: Array<{ name: string; host: string; verify_ssl: boolean }> = [];
 const keyMap = new Map<string, string>();
 
@@ -122,7 +173,15 @@ export function resolveFirewall(name?: string): FirewallEntry | null {
   // No config entries — fall back to env vars
   const host = sanitizeHost(process.env.PANOS_HOST ?? "");
   const api_key = (process.env.PANOS_API_KEY ?? "").trim();
-  if (host && api_key) return { name: "env", host, api_key, verify_ssl: false };
+  // Aviz/NCP default: verify TLS unless explicitly disabled (lab self-signed).
+  if (host && api_key) {
+    return {
+      name: "env",
+      host,
+      api_key,
+      verify_ssl: parseEnvBool(process.env.PANOS_VERIFY_TLS, true),
+    };
+  }
 
   return null;
 }

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -1,0 +1,73 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { registerFirewallTools } from "./tools/firewalls.js";
+import { registerSystemTools } from "./tools/system.js";
+import { registerNetworkTools } from "./tools/network.js";
+import { registerSecurityTools } from "./tools/security.js";
+import { registerObjectsTools } from "./tools/objects.js";
+import { registerNatTools } from "./tools/nat.js";
+import { registerUserIdTools } from "./tools/userid.js";
+import { registerAdminTools } from "./tools/admin.js";
+import { registerVpnTools } from "./tools/vpn.js";
+import { registerPanoramaTools } from "./tools/panorama.js";
+import { registerLogsTools } from "./tools/logs.js";
+import { registerThreatTools } from "./tools/threat.js";
+import { registerCertificatesTools } from "./tools/certificates.js";
+import { registerLicensesTools } from "./tools/licenses.js";
+import { registerConfigTools } from "./tools/config.js";
+import { registerUtilityTools } from "./tools/utility.js";
+import { registerNetopsWrapperTools } from "./tools/netopsWrappers.js";
+
+const SERVER_VERSION = "1.3.29";
+
+/** Create a fully registered PAN-OS MCP server (one instance per SSE session). */
+export function createPanosMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "panos-mcp",
+    version: SERVER_VERSION,
+  });
+
+  // Wrap all tool handlers to catch unexpected errors cleanly
+  const _tool = server.tool.bind(server);
+  (server.tool as any) = function (...args: any[]) {
+    const last = args.length - 1;
+    const handler = args[last];
+    args[last] = async (...hArgs: any[]) => {
+      try {
+        return await handler(...hArgs);
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+        };
+      }
+    };
+    return (_tool as (...a: any[]) => any)(...args);
+  };
+
+  registerFirewallTools(server);
+  registerSystemTools(server);
+  registerNetworkTools(server);
+  registerSecurityTools(server);
+  registerObjectsTools(server);
+  registerNatTools(server);
+  registerUserIdTools(server);
+  registerAdminTools(server);
+  registerVpnTools(server);
+  registerPanoramaTools(server);
+  registerLogsTools(server);
+  registerThreatTools(server);
+  registerCertificatesTools(server);
+  registerLicensesTools(server);
+  registerConfigTools(server);
+  registerUtilityTools(server);
+  registerNetopsWrapperTools(server);
+
+  return server;
+}
+
+export { SERVER_VERSION };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,83 +1,47 @@
 #!/usr/bin/env node
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadFirewallConfig } from "./config/firewalls.js";
+import { loadFirewallConfig, ensureNcpEnvFirewall } from "./config/firewalls.js";
 import { isKeychainAvailable } from "./config/keychain.js";
 import { describeProxy } from "./api/proxy.js";
+import { createPanosMcpServer } from "./createServer.js";
+import { startLocalMcpHttp } from "./localmcpHttp.js";
 
-import { registerFirewallTools } from "./tools/firewalls.js";
-import { registerSystemTools } from "./tools/system.js";
-import { registerNetworkTools } from "./tools/network.js";
-import { registerSecurityTools } from "./tools/security.js";
-import { registerObjectsTools } from "./tools/objects.js";
-import { registerNatTools } from "./tools/nat.js";
-import { registerUserIdTools } from "./tools/userid.js";
-import { registerAdminTools } from "./tools/admin.js";
-import { registerVpnTools } from "./tools/vpn.js";
-import { registerPanoramaTools } from "./tools/panorama.js";
-import { registerLogsTools } from "./tools/logs.js";
-import { registerThreatTools } from "./tools/threat.js";
-import { registerCertificatesTools } from "./tools/certificates.js";
-import { registerLicensesTools } from "./tools/licenses.js";
-import { registerConfigTools } from "./tools/config.js";
-import { registerUtilityTools } from "./tools/utility.js";
-
-const server = new McpServer({
-  name: "panos-mcp",
-  version: "1.3.29",
-});
-
-// Wrap all tool handlers to catch unexpected errors cleanly
-const _tool = server.tool.bind(server);
-(server.tool as any) = function (...args: any[]) {
-  const last = args.length - 1;
-  const handler = args[last];
-  args[last] = async (...hArgs: any[]) => {
-    try {
-      return await handler(...hArgs);
-    } catch (error) {
-      return {
-        content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-      };
-    }
-  };
-  return (_tool as (...a: any[]) => any)(...args);
-};
-
-// Register all tools
-registerFirewallTools(server);
-registerSystemTools(server);
-registerNetworkTools(server);
-registerSecurityTools(server);
-registerObjectsTools(server);
-registerNatTools(server);
-registerUserIdTools(server);
-registerAdminTools(server);
-registerVpnTools(server);
-registerPanoramaTools(server);
-registerLogsTools(server);
-registerThreatTools(server);
-registerCertificatesTools(server);
-registerLicensesTools(server);
-registerConfigTools(server);
-registerUtilityTools(server);
-
-async function main() {
+async function bootstrap(): Promise<void> {
   await loadFirewallConfig();
+  await ensureNcpEnvFirewall();
+
   if (!isKeychainAvailable()) {
     process.stderr.write(
       "[panos-mcp] WARNING: System keychain unavailable — API keys are stored in plaintext. " +
-      "Install a keychain provider (macOS Keychain, libsecret on Linux, Windows Credential Manager) " +
-      "and re-run `panos-mcp keygen` to migrate keys to secure storage.\n"
+        "Install a keychain provider (macOS Keychain, libsecret on Linux, Windows Credential Manager) " +
+        "and re-run `panos-mcp keygen` to migrate keys to secure storage.\n"
     );
   }
   const proxy = describeProxy();
   if (proxy) {
     console.error(`PanOS proxy: ${proxy}`);
   }
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
 }
 
-main().catch(console.error);
+async function main(): Promise<void> {
+  await bootstrap();
+
+  const transport = (process.env.MCP_TRANSPORT || "stdio").trim().toLowerCase();
+  const localMcp = ["1", "true", "yes", "on"].includes(
+    (process.env.LOCAL_MCP_MODE || "").trim().toLowerCase()
+  );
+
+  if (transport === "sse" || localMcp) {
+    await startLocalMcpHttp();
+    return;
+  }
+
+  const server = createPanosMcpServer();
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/localmcpHttp.ts
+++ b/src/localmcpHttp.ts
@@ -1,0 +1,128 @@
+import http from "node:http";
+import { URL } from "node:url";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { createPanosMcpServer, SERVER_VERSION } from "./createServer.js";
+
+const SSE_PATH = "/mcp/sse";
+const MESSAGES_PATH = "/mcp/messages";
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function unauthorized(res: http.ServerResponse): void {
+  res.writeHead(401, { "Content-Type": "text/plain" });
+  res.end("Unauthorized");
+}
+
+function checkMcpAuth(req: http.IncomingMessage): boolean {
+  const expected = (process.env.MCP_API_TOKEN || "").trim();
+  if (!expected) return true;
+
+  const header = req.headers.authorization || "";
+  const token = header.toLowerCase().startsWith("bearer ")
+    ? header.slice(7).trim()
+    : header.trim();
+  return token === expected;
+}
+
+/**
+ * NCP LocalMCP HTTP+SSE transport.
+ * Compatible with ncp-api mcp_client (GET /mcp/sse, POST /mcp/messages?sessionId=...).
+ */
+export async function startLocalMcpHttp(): Promise<void> {
+  const host = process.env.MCP_BIND_HOST || "0.0.0.0";
+  const port = Number(process.env.MCP_PORT || process.env.MCP_SERVER_PORT || "8001");
+  const enforceAuth = Boolean((process.env.MCP_API_TOKEN || "").trim());
+
+  const transports = new Map<string, SSEServerTransport>();
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+      const path = url.pathname;
+
+      if (req.method === "GET" && path === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, version: SERVER_VERSION, transport: "sse" }));
+        return;
+      }
+
+      if (enforceAuth && !checkMcpAuth(req)) {
+        unauthorized(res);
+        return;
+      }
+
+      if (req.method === "GET" && path === SSE_PATH) {
+        const transport = new SSEServerTransport(MESSAGES_PATH, res, {
+          enableDnsRebindingProtection: false,
+        });
+        const sessionId = transport.sessionId;
+        transports.set(sessionId, transport);
+        transport.onclose = () => {
+          transports.delete(sessionId);
+        };
+
+        const mcp = createPanosMcpServer();
+        await mcp.connect(transport);
+        return;
+      }
+
+      if (req.method === "POST" && path === MESSAGES_PATH) {
+        const sessionId = url.searchParams.get("sessionId");
+        if (!sessionId) {
+          res.writeHead(400, { "Content-Type": "text/plain" });
+          res.end("Missing sessionId");
+          return;
+        }
+        const transport = transports.get(sessionId);
+        if (!transport) {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end("Session not found");
+          return;
+        }
+
+        const raw = await readBody(req);
+        let parsed: unknown = undefined;
+        if (raw) {
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            res.writeHead(400, { "Content-Type": "text/plain" });
+            res.end("Invalid JSON body");
+            return;
+          }
+        }
+        await transport.handlePostMessage(req, res, parsed);
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    } catch (error) {
+      process.stderr.write(
+        `[ncp-paloalto-mcp] request error: ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end("Internal server error");
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      const authNote = enforceAuth ? "MCP_API_TOKEN required" : "no MCP auth token set";
+      process.stderr.write(
+        `[ncp-paloalto-mcp] LocalMCP SSE listening on http://${host}:${port}${SSE_PATH} (${authNote})\n`
+      );
+      resolve();
+    });
+  });
+}

--- a/src/parse/licenses.ts
+++ b/src/parse/licenses.ts
@@ -1,0 +1,46 @@
+/** Normalize PAN-OS license info responses. */
+
+function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function flatten(value: unknown): unknown {
+  if (value && typeof value === "object" && "#text" in (value as object)) {
+    return (value as Record<string, unknown>)["#text"];
+  }
+  return value;
+}
+
+function flattenEntry(entry: unknown): Record<string, unknown> {
+  if (!entry || typeof entry !== "object") return { value: entry };
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(entry as Record<string, unknown>)) {
+    out[key] = flatten(value);
+  }
+  return out;
+}
+
+export function normalizeLicenses(data: unknown): Record<string, unknown> {
+  if (data == null) {
+    return { licenses: [], count: 0, has_entries: false };
+  }
+
+  const root = data as Record<string, unknown>;
+  let entries: Record<string, unknown>[] = [];
+
+  const licenses = root.licenses as Record<string, unknown> | undefined;
+  if (licenses?.entry != null) {
+    entries = asArray(licenses.entry).map(flattenEntry);
+  } else if (root.entry != null) {
+    entries = asArray(root.entry).map(flattenEntry);
+  } else if (root.result && typeof root.result === "object") {
+    return normalizeLicenses(root.result);
+  }
+
+  return {
+    licenses: entries,
+    count: entries.length,
+    has_entries: entries.length > 0,
+  };
+}

--- a/src/parse/logResults.ts
+++ b/src/parse/logResults.ts
@@ -1,0 +1,61 @@
+/** Normalize PAN-OS log API poll payloads for agents and UIs. */
+
+function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export function extractJobId(job: unknown): string | null {
+  if (job == null) return null;
+  if (typeof job === "string" || typeof job === "number") return String(job);
+  if (typeof job === "object") {
+    const obj = job as Record<string, unknown>;
+    const id = obj.id ?? obj["#text"];
+    if (id != null) return String(id);
+  }
+  return null;
+}
+
+export function formatPanOsLogTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+/** Build PAN-OS log query filter for a relative hours lookback. */
+export function buildLogTimeQuery(hours: number, extraQuery?: string): string {
+  const since = new Date(Date.now() - hours * 3_600_000);
+  const timePart = `( receive_time geq '${formatPanOsLogTime(since)}' )`;
+  const extra = extraQuery?.trim();
+  if (!extra) return timePart;
+  return `( ${timePart} and ${extra} )`;
+}
+
+export function normalizeLogResults(raw: unknown): Record<string, unknown> {
+  const root = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const countRaw = root["@_count"] ?? root["@count"];
+  const count = countRaw != null ? Number(countRaw) : null;
+  const entries = asArray(root.entry).map((entry) => flattenLogEntry(entry));
+
+  return {
+    count: Number.isFinite(count) ? count : entries.length,
+    progress: root["@_progress"] ?? root["@progress"] ?? null,
+    entries,
+    has_entries: entries.length > 0,
+  };
+}
+
+function flattenLogEntry(entry: unknown): Record<string, unknown> {
+  if (!entry || typeof entry !== "object") return { value: entry };
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(entry as Record<string, unknown>)) {
+    if (value && typeof value === "object" && "#text" in (value as object)) {
+      out[key] = (value as Record<string, unknown>)["#text"];
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}

--- a/src/parse/systemResources.ts
+++ b/src/parse/systemResources.ts
@@ -1,0 +1,149 @@
+export const PRESENTATION_RULES = [
+  "system_cpu is the only overall CPU figure. Report user_pct / idle_pct from there.",
+  "top_processes[].percent_cpu is per-core. Several pan_task rows at ~90-100 is normal PAN-OS data-plane behavior, including when active sessions are 0.",
+  "Do not average process percent_cpu into overall CPU, and do not call that an incident by itself.",
+  "memory.used_pct is RAM. Never label it as CPU.",
+  "Do not assume core count from the hardware model. Use observed_logical_cpus only if present.",
+  "Do not recommend reboot or config changes unless the user asks for remediation.",
+];
+
+const LOAD_RE = /load average:\s*([\d.]+),\s*([\d.]+),\s*([\d.]+)/i;
+const CPU_RE = /%Cpu\(s\):\s*([\d.]+)\s*us,\s*([\d.]+)\s*sy,\s*([\d.]+)\s*ni,\s*([\d.]+)\s*id/i;
+const MEM_RE =
+  /MiB Mem\s*:\s*([\d.]+)\s*total,\s*([\d.]+)\s*free,\s*([\d.]+)\s*used,\s*([\d.]+)\s*buff\/cache/i;
+const SWAP_RE = /MiB Swap:\s*([\d.]+)\s*total,\s*([\d.]+)\s*free,\s*([\d.]+)\s*used/i;
+const RCUC_RE = /rcuc\/(\d+)/g;
+const PROC_RE = /^\s*(\d+)\s+.*?\s([RSDZTW])\s+([\d.]+)\s+([\d.]+)\s+(\S+)\s+(\S+)\s*$/;
+
+export function asText(data: unknown): string {
+  if (data == null) return "";
+  if (typeof data === "string") return data;
+  if (typeof data === "number" || typeof data === "boolean") return String(data);
+  if (typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    if (typeof obj["#text"] === "string") return obj["#text"];
+    if (typeof obj.data === "string") return obj.data;
+  }
+  return "";
+}
+
+function pct(used: number, total: number): number | null {
+  if (total <= 0) return null;
+  return Math.round((used / total) * 1000) / 10;
+}
+
+export function parseSystemResources(
+  raw: unknown,
+  processLimit = 8
+): Record<string, unknown> {
+  const text = asText(raw);
+  const lines = text.split(/\r?\n/);
+  const parsed: Record<string, unknown> = {
+    parse_ok: false,
+    presentation_rules: PRESENTATION_RULES,
+    header: lines.slice(0, 6).join("\n").trim(),
+  };
+
+  const load = LOAD_RE.exec(text);
+  const cpu = CPU_RE.exec(text);
+  const mem = MEM_RE.exec(text);
+  const swap = SWAP_RE.exec(text);
+  if (!load || !cpu || !mem) {
+    parsed.parse_error = "Could not parse top header; see header/raw_excerpt";
+    parsed.raw_excerpt = lines.slice(0, 12).join("\n");
+    return parsed;
+  }
+
+  const userPct = Number(cpu[1]);
+  const systemPct = Number(cpu[2]);
+  const nicePct = Number(cpu[3]);
+  const idlePct = Number(cpu[4]);
+  const memTotal = Number(mem[1]);
+  const memFree = Number(mem[2]);
+  const memUsed = Number(mem[3]);
+  const memCache = Number(mem[4]);
+
+  const processes: Array<Record<string, unknown>> = [];
+  for (const line of lines) {
+    const match = PROC_RE.exec(line);
+    if (!match) continue;
+    processes.push({
+      pid: Number(match[1]),
+      percent_cpu: Number(match[3]),
+      percent_mem: Number(match[4]),
+      command: match[6],
+    });
+    if (processes.length >= processLimit) break;
+  }
+
+  const rcuc = [...text.matchAll(RCUC_RE)].map((m) => Number(m[1]));
+  const observed = rcuc.length ? Math.max(...rcuc) + 1 : null;
+
+  parsed.parse_ok = true;
+  parsed.load_average = {
+    "1min": Number(load[1]),
+    "5min": Number(load[2]),
+    "15min": Number(load[3]),
+  };
+  parsed.system_cpu = {
+    user_pct: userPct,
+    system_pct: systemPct,
+    nice_pct: nicePct,
+    idle_pct: idlePct,
+    busy_pct: Math.round((userPct + systemPct + nicePct) * 10) / 10,
+    scope: "all_cores_combined",
+  };
+  parsed.memory = {
+    total_mib: memTotal,
+    used_mib: memUsed,
+    free_mib: memFree,
+    buff_cache_mib: memCache,
+    used_pct: pct(memUsed, memTotal),
+    scope: "ram",
+  };
+  parsed.top_processes = processes;
+  parsed.observed_logical_cpus = observed;
+
+  if (swap) {
+    const swapTotal = Number(swap[1]);
+    const swapUsed = Number(swap[3]);
+    parsed.swap = {
+      total_mib: swapTotal,
+      free_mib: Number(swap[2]),
+      used_mib: swapUsed,
+      used_pct: pct(swapUsed, swapTotal),
+    };
+  }
+
+  parsed.labeled_summary = buildLabeledSummary(parsed);
+  return parsed;
+}
+
+function buildLabeledSummary(parsed: Record<string, unknown>): Record<string, unknown> {
+  const cpu = parsed.system_cpu as Record<string, number>;
+  const mem = parsed.memory as Record<string, number>;
+  const load = parsed.load_average as Record<string, number>;
+  const top = (parsed.top_processes as Array<Record<string, unknown>>) ?? [];
+
+  const memUsedPct = mem.used_pct as number;
+  const memFreePct = pct(mem.free_mib, mem.total_mib);
+  const memCachePct = pct(mem.buff_cache_mib, mem.total_mib);
+
+  return {
+    "CPU - User": `${cpu.user_pct}%`,
+    "CPU - System": `${cpu.system_pct}%`,
+    "CPU - Idle": `${cpu.idle_pct}%`,
+    "Overall CPU Utilization": `${cpu.busy_pct}% (user + system + nice)`,
+    "Memory - Used": `${memUsedPct}% (≈ ${mem.used_mib} MiB of ${mem.total_mib} MiB)`,
+    "Memory - Free": `${memFreePct ?? "n/a"}% (≈ ${mem.free_mib} MiB)`,
+    "Memory - Buff/Cache": `${memCachePct ?? "n/a"}% (≈ ${mem.buff_cache_mib} MiB)`,
+    "Load Average (1/5/15 min)": `${load["1min"]}, ${load["5min"]}, ${load["15min"]}`,
+    observed_logical_cpus: parsed.observed_logical_cpus,
+    top_cpu_processes: top.map((p) => ({
+      pid: p.pid,
+      command: p.command,
+      percent_cpu: p.percent_cpu,
+      percent_mem: p.percent_mem,
+    })),
+  };
+}

--- a/src/schemas/panos.ts
+++ b/src/schemas/panos.ts
@@ -58,12 +58,22 @@ export const logQuery = z
   .optional()
   .describe("Filter query for log retrieval");
 
-export const firewallName = z
-  .string()
+export const logHoursSchema = z
+  .number()
+  .int()
   .min(1)
-  .max(63)
+  .max(168)
   .optional()
-  .describe("Target firewall name (from firewalls.json). Required when multiple firewalls are configured; optional otherwise.");
+  .describe(
+    "Optional lookback window in hours. Builds a receive_time filter (e.g. 24 = last 24 hours)."
+  );
+
+export const firewallName = z.preprocess(
+  (value) => (value === "" || value === null ? undefined : value),
+  z.string().min(1).max(63).optional()
+).describe(
+  "Optional named firewall target. For NCP LocalMCP leave unset — the connector already targets one firewall. Only pass a name when multiple firewalls are configured."
+);
 
 export const firewallHost = z
   .string()

--- a/src/tools/licenses.ts
+++ b/src/tools/licenses.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { executeOpCommand, formatResponse, resolveTarget, isApiError } from "../api/client.js";
 import { firewallName } from "../schemas/panos.js";
+import { normalizeLicenses } from "../parse/licenses.js";
 
 export function registerLicensesTools(server: McpServer) {
   server.tool(
@@ -14,6 +15,9 @@ export function registerLicensesTools(server: McpServer) {
       const target = resolveTarget(firewall);
       if (isApiError(target)) return formatResponse(target);
       const result = await executeOpCommand("<request><license><info></info></license></request>", target);
+      if (result.success) {
+        result.data = normalizeLicenses(result.data);
+      }
       return formatResponse(result);
     }
   );

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,90 +1,77 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { executeLogQuery, formatResponse, resolveTarget, isApiError } from "../api/client.js";
-import { nlogsSchema, logQuery, firewallName } from "../schemas/panos.js";
+import { nlogsSchema, logQuery, logHoursSchema, firewallName } from "../schemas/panos.js";
+
+function registerLogTool(
+  server: McpServer,
+  name: string,
+  logType: string,
+  description: string,
+  queryHint: string
+) {
+  server.tool(
+    name,
+    description,
+    {
+      nlogs: nlogsSchema,
+      hours: logHoursSchema,
+      query: logQuery.describe(queryHint),
+      firewall: firewallName,
+    },
+    { title: name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()), readOnlyHint: true, destructiveHint: false },
+    async ({ nlogs, hours, query, firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const result = await executeLogQuery(
+        logType,
+        nlogs || 20,
+        query,
+        target,
+        hours
+      );
+      return formatResponse(result);
+    }
+  );
+}
 
 export function registerLogsTools(server: McpServer) {
-  server.tool(
+  registerLogTool(
+    server,
     "get_traffic_logs",
-    "[READ-ONLY] Retrieves recent traffic logs from the firewall using the PanOS log API (type=log). Supports filtering by query and limiting result count.",
-    {
-      nlogs: nlogsSchema,
-      query: logQuery.describe("Filter query (e.g., '( addr.src in 10.0.0.0/8 )')"),
-      firewall: firewallName,
-    },
-    { title: "Get Traffic Logs", readOnlyHint: true, destructiveHint: false },
-    async ({ nlogs, query, firewall }) => {
-      const target = resolveTarget(firewall);
-      if (isApiError(target)) return formatResponse(target);
-      const result = await executeLogQuery("traffic", nlogs || 20, query, target);
-      return formatResponse(result);
-    }
+    "traffic",
+    "[READ-ONLY] Retrieves traffic logs from the PanOS log API. Use hours for a time window (e.g. 24 = last 24h) and optional query filter.",
+    "Optional extra filter (e.g., '( action eq deny )')"
   );
 
-  server.tool(
+  registerLogTool(
+    server,
     "get_threat_logs",
-    "[READ-ONLY] Retrieves recent threat logs from the firewall using the PanOS log API (type=log). Supports filtering by query and limiting result count.",
-    {
-      nlogs: nlogsSchema,
-      query: logQuery.describe("Filter query (e.g., '( severity eq critical )')"),
-      firewall: firewallName,
-    },
-    { title: "Get Threat Logs", readOnlyHint: true, destructiveHint: false },
-    async ({ nlogs, query, firewall }) => {
-      const target = resolveTarget(firewall);
-      if (isApiError(target)) return formatResponse(target);
-      const result = await executeLogQuery("threat", nlogs || 20, query, target);
-      return formatResponse(result);
-    }
+    "threat",
+    "[READ-ONLY] Retrieves threat logs from the PanOS log API. Use hours for a time window and optional query filter.",
+    "Optional extra filter (e.g., '( severity eq critical )')"
   );
 
-  server.tool(
+  registerLogTool(
+    server,
     "get_system_logs",
-    "[READ-ONLY] Retrieves recent system logs from the firewall using the PanOS log API (type=log). Supports filtering by query and limiting result count.",
-    {
-      nlogs: nlogsSchema,
-      query: logQuery.describe("Filter query (e.g., '( severity eq critical )')"),
-      firewall: firewallName,
-    },
-    { title: "Get System Logs", readOnlyHint: true, destructiveHint: false },
-    async ({ nlogs, query, firewall }) => {
-      const target = resolveTarget(firewall);
-      if (isApiError(target)) return formatResponse(target);
-      const result = await executeLogQuery("system", nlogs || 20, query, target);
-      return formatResponse(result);
-    }
+    "system",
+    "[READ-ONLY] Retrieves system logs from the PanOS log API. Use hours for a time window (e.g. 24 = last 24h) and optional query filter.",
+    "Optional extra filter (e.g., '( subtype eq commit )')"
   );
 
-  server.tool(
+  registerLogTool(
+    server,
     "get_config_logs",
-    "[READ-ONLY] Retrieves recent configuration change logs from the firewall using the PanOS log API (type=log). Supports filtering by query and limiting result count.",
-    {
-      nlogs: nlogsSchema,
-      query: logQuery.describe("Filter query"),
-      firewall: firewallName,
-    },
-    { title: "Get Config Logs", readOnlyHint: true, destructiveHint: false },
-    async ({ nlogs, query, firewall }) => {
-      const target = resolveTarget(firewall);
-      if (isApiError(target)) return formatResponse(target);
-      const result = await executeLogQuery("config", nlogs || 20, query, target);
-      return formatResponse(result);
-    }
+    "config",
+    "[READ-ONLY] Retrieves configuration change logs from the PanOS log API. Use hours for a time window and optional query filter.",
+    "Optional extra filter"
   );
 
-  server.tool(
+  registerLogTool(
+    server,
     "get_url_filter_logs",
-    "[READ-ONLY] Retrieves recent URL filtering logs from the firewall using the PanOS log API (type=log&log-type=url). Shows URLs visited and actions taken (allow/block/continue/override) by URL filtering policy.",
-    {
-      nlogs: nlogsSchema,
-      query: logQuery.describe("Filter query (e.g., '( action eq block )' or '( category eq malware )')"),
-      firewall: firewallName,
-    },
-    { title: "Get URL Filter Logs", readOnlyHint: true, destructiveHint: false },
-    async ({ nlogs, query, firewall }) => {
-      const target = resolveTarget(firewall);
-      if (isApiError(target)) return formatResponse(target);
-      const result = await executeLogQuery("url", nlogs || 20, query, target);
-      return formatResponse(result);
-    }
+    "url",
+    "[READ-ONLY] Retrieves URL filtering logs from the PanOS log API. Use hours for a time window and optional query filter.",
+    "Optional extra filter (e.g., '( action eq block )')"
   );
 }

--- a/src/tools/netopsWrappers.ts
+++ b/src/tools/netopsWrappers.ts
@@ -1,0 +1,83 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { executeOpCommand, formatResponse, resolveTarget, isApiError } from "../api/client.js";
+import { firewallName, xmlEscape } from "../schemas/panos.js";
+
+function vsysName(): string {
+  const vsys = (process.env.PANOS_VSYS || "vsys1").trim() || "vsys1";
+  return xmlEscape(vsys);
+}
+
+/** Aviz NetOps wrappers for PAN-OS calls missing (or raw) in upstream Palo-MCP. */
+export function registerNetopsWrapperTools(server: McpServer) {
+  server.tool(
+    "get_interface_counters",
+    "[READ-ONLY] Retrieves packet, byte, drop, and error counters for all interfaces. Executes: show counter interface all.",
+    { firewall: firewallName },
+    { title: "Get Interface Counters", readOnlyHint: true, destructiveHint: false },
+    async ({ firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const result = await executeOpCommand(
+        "<show><counter><interface>all</interface></counter></show>",
+        target
+      );
+      return formatResponse(result);
+    }
+  );
+
+  server.tool(
+    "get_rule_hit_counts",
+    "[READ-ONLY] Retrieves runtime hit counts for local security policy rules. Executes: show rule-hit-count vsys security all.",
+    { firewall: firewallName },
+    { title: "Get Rule Hit Counts", readOnlyHint: true, destructiveHint: false },
+    async ({ firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const vsys = vsysName();
+      const cmd =
+        "<show><rule-hit-count><vsys><vsys-name>" +
+        `<entry name="${vsys}"><rule-base><entry name="security">` +
+        "<rules><all/></rules></entry></rule-base></entry>" +
+        "</vsys-name></vsys></rule-hit-count></show>";
+      const result = await executeOpCommand(cmd, target);
+      return formatResponse(result);
+    }
+  );
+
+  server.tool(
+    "get_environmentals",
+    "[READ-ONLY] Retrieves hardware temperature, fan, and power-supply readings. Executes: show system environmentals.",
+    { firewall: firewallName },
+    { title: "Get Environmentals", readOnlyHint: true, destructiveHint: false },
+    async ({ firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const result = await executeOpCommand(
+        "<show><system><environmentals></environmentals></system></show>",
+        target
+      );
+      return formatResponse(result);
+    }
+  );
+
+  server.tool(
+    "get_ntp_and_clock",
+    "[READ-ONLY] Retrieves firewall clock and NTP synchronization state. Executes: show clock and show ntp.",
+    { firewall: firewallName },
+    { title: "Get NTP And Clock", readOnlyHint: true, destructiveHint: false },
+    async ({ firewall }) => {
+      const target = resolveTarget(firewall);
+      if (isApiError(target)) return formatResponse(target);
+      const [clock, ntp] = await Promise.all([
+        executeOpCommand("<show><clock></clock></show>", target),
+        executeOpCommand("<show><ntp></ntp></show>", target),
+      ]);
+      if (!clock.success) return formatResponse(clock);
+      if (!ntp.success) return formatResponse(ntp);
+      return formatResponse({
+        success: true,
+        data: { clock: clock.data, ntp: ntp.data },
+      });
+    }
+  );
+}

--- a/src/tools/security.ts
+++ b/src/tools/security.ts
@@ -114,7 +114,7 @@ export function registerSecurityTools(server: McpServer) {
       log_start: z.boolean().optional().describe("Log at session start"),
       profile_group: z.string().optional().describe("Security profile group name to apply"),
       description: z.string().max(1023).optional().describe("Optional description"),
-      disabled: z.boolean().optional().describe("Create rule in disabled state"),
+      disabled: z.boolean().optional().describe("Create rule in disabled state (Aviz default: true)"),
       tag: z.array(z.string().min(1)).optional().describe("Tags to apply to the rule"),
       firewall: firewallName,
     },
@@ -135,7 +135,8 @@ export function registerSecurityTools(server: McpServer) {
       if (log_start !== undefined) element += `<log-start>${log_start ? "yes" : "no"}</log-start>`;
       if (profile_group) element += `<profile-setting><group><member>${xmlEscape(profile_group)}</member></group></profile-setting>`;
       if (description) element += `<description>${xmlEscape(description)}</description>`;
-      if (disabled !== undefined) element += `<disabled>${disabled ? "yes" : "no"}</disabled>`;
+      const disabledFlag = disabled ?? true;
+      element += `<disabled>${disabledFlag ? "yes" : "no"}</disabled>`;
       if (tag && tag.length > 0) element += `<tag>${members(tag)}</tag>`;
       element += `</entry>`;
       const result = await setConfig(xpath, element, target);

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { executeOpCommand, formatResponse, resolveTarget, isApiError } from "../api/client.js";
+import { parseSystemResources } from "../parse/systemResources.js";
 import { firewallName } from "../schemas/panos.js";
 
 export function registerSystemTools(server: McpServer) {
@@ -53,7 +54,7 @@ export function registerSystemTools(server: McpServer) {
 
   server.tool(
     "get_system_resources",
-    "[READ-ONLY] Retrieves system resource utilization including CPU, memory, and disk usage. Executes: show system resources.",
+    "[READ-ONLY] Retrieves labeled CPU, memory, load, and top-process metrics from show system resources. Response includes labeled_summary (CPU - User, Memory - Used, top_cpu_processes) plus structured system_cpu, memory, load_average, top_processes. Process percent_cpu is per-core (pan_task near 100% is normal). memory.used_pct is RAM, never CPU.",
     {
       firewall: firewallName,
     },
@@ -62,7 +63,11 @@ export function registerSystemTools(server: McpServer) {
       const target = resolveTarget(firewall);
       if (isApiError(target)) return formatResponse(target);
       const result = await executeOpCommand("<show><system><resources></resources></system></show>", target);
-      return formatResponse(result);
+      if (!result.success) return formatResponse(result);
+      return formatResponse({
+        success: true,
+        data: parseSystemResources(result.data),
+      });
     }
   );
 }

--- a/tests/config/firewalls.test.ts
+++ b/tests/config/firewalls.test.ts
@@ -42,6 +42,7 @@ describe("firewalls config", () => {
     delete process.env.PANOS_FIREWALLS_CONFIG;
     delete process.env.PANOS_HOST;
     delete process.env.PANOS_API_KEY;
+    delete process.env.PANOS_VERIFY_TLS;
   });
 
   describe("no config file — env var fallback", () => {
@@ -57,7 +58,15 @@ describe("firewalls config", () => {
     it("resolves to env entry when env vars are set", () => {
       process.env.PANOS_HOST = "10.0.0.1";
       process.env.PANOS_API_KEY = "key123";
-      expect(resolveFirewall()).toEqual({ name: "env", host: "10.0.0.1", api_key: "key123", verify_ssl: false });
+      expect(resolveFirewall()).toEqual({ name: "env", host: "10.0.0.1", api_key: "key123", verify_ssl: true });
+    });
+
+    it("honors PANOS_VERIFY_TLS=false for lab self-signed certs", () => {
+      process.env.PANOS_HOST = "10.0.0.1";
+      process.env.PANOS_API_KEY = "key123";
+      process.env.PANOS_VERIFY_TLS = "false";
+      expect(resolveFirewall()?.verify_ssl).toBe(false);
+      delete process.env.PANOS_VERIFY_TLS;
     });
 
     it("isMultiFirewall returns false", () => {

--- a/tests/parse/licenses.test.ts
+++ b/tests/parse/licenses.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { normalizeLicenses } from "../../src/parse/licenses.js";
+
+describe("normalizeLicenses", () => {
+  it("extracts license entries", () => {
+    const normalized = normalizeLicenses({
+      licenses: {
+        entry: [
+          { feature: "Threat Prevention", expired: "no" },
+          { feature: "PAN-DB URL Filtering", expired: "no" },
+        ],
+      },
+    });
+    expect(normalized.count).toBe(2);
+    expect(normalized.has_entries).toBe(true);
+    expect((normalized.licenses as Array<Record<string, unknown>>)[0].feature).toBe(
+      "Threat Prevention"
+    );
+  });
+
+  it("handles empty license response", () => {
+    const normalized = normalizeLicenses({ licenses: {} });
+    expect(normalized.count).toBe(0);
+    expect(normalized.has_entries).toBe(false);
+  });
+});

--- a/tests/parse/logResults.test.ts
+++ b/tests/parse/logResults.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractJobId,
+  buildLogTimeQuery,
+  normalizeLogResults,
+} from "../../src/parse/logResults.js";
+
+describe("logResults", () => {
+  it("extracts job id from string or object", () => {
+    expect(extractJobId("410")).toBe("410");
+    expect(extractJobId({ id: "411", status: "FIN" })).toBe("411");
+    expect(extractJobId(null)).toBeNull();
+  });
+
+  it("builds receive_time query for hours lookback", () => {
+    const q = buildLogTimeQuery(24);
+    expect(q).toMatch(/receive_time geq/);
+    expect(q).toMatch(/^\( receive_time geq '/);
+  });
+
+  it("normalizes log entries and count", () => {
+    const normalized = normalizeLogResults({
+      "@_count": "2",
+      "@_progress": "100",
+      entry: [
+        { subtype: { "#text": "auth" }, msg: { "#text": "login ok" } },
+        { subtype: "commit", msg: "committed" },
+      ],
+    });
+    expect(normalized.count).toBe(2);
+    expect(normalized.has_entries).toBe(true);
+    expect(normalized.entries).toHaveLength(2);
+    expect((normalized.entries as Array<Record<string, unknown>>)[0].subtype).toBe("auth");
+  });
+
+  it("handles empty log result", () => {
+    const normalized = normalizeLogResults({ "@_count": "0", "@_progress": "100" });
+    expect(normalized.count).toBe(0);
+    expect(normalized.has_entries).toBe(false);
+    expect(normalized.entries).toEqual([]);
+  });
+});

--- a/tests/parse/systemResources.test.ts
+++ b/tests/parse/systemResources.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseSystemResources } from "../../src/parse/systemResources.js";
+
+const SAMPLE = `top - 14:54:19 up 84 days,  9:53,  0 users,  load average: 5.37, 5.54, 5.58
+Tasks: 195 total,   7 running, 188 sleeping,   0 stopped,   0 zombie
+%Cpu(s): 65.1 us,  2.0 sy,  0.0 ni, 32.9 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
+MiB Mem :   5026.9 total,    691.6 free,   2858.9 used,   1476.4 buff/cache
+MiB Swap:   5961.0 total,   5904.8 free,     56.3 used.   1337.9 avail Mem
+
+  PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+ 5971       20   0  120212   6044   3336 R 100.0   0.1 121510:09 pan_task
+ 5972       20   0  120212   6140   3428 R 100.0   0.1 121512:07 pan_task
+ 5974       20   0  120212   6360   3652 R 100.0   0.1 121504:20 pan_task
+ 5978       20   0  120212   6104   3376 R 100.0   0.1 121328:48 pan_task
+ 5979       20   0  145260  31328   3516 R 100.0   0.6 121508:10 pan_task
+   10       20   0       0      0      0 S   0.0   0.0  71:17.60 rcuc/0
+   11       20   0       0      0      0 S   0.0   0.0  32:14.66 rcuc/1
+   16       20   0       0      0      0 S   0.0   0.0  28:51.85 rcuc/2
+   21       20   0       0      0      0 S   0.0   0.0  30:46.65 rcuc/3
+   26       20   0       0      0      0 S   0.0   0.0  28:25.42 rcuc/4
+   31       20   0       0      0      0 S   0.0   0.0  29:38.02 rcuc/5
+   36       20   0       0      0      0 S   0.0   0.0  74:38.41 rcuc/6
+   41       20   0       0      0      0 S   0.0   0.0  73:31.80 rcuc/7
+`;
+
+describe("parseSystemResources", () => {
+  it("labels system CPU separately from pan_task and RAM", () => {
+    const parsed = parseSystemResources(SAMPLE);
+
+    expect(parsed.parse_ok).toBe(true);
+    expect(parsed.system_cpu).toMatchObject({
+      scope: "all_cores_combined",
+      user_pct: 65.1,
+      idle_pct: 32.9,
+      busy_pct: 67.1,
+    });
+    expect(parsed.memory).toMatchObject({
+      scope: "ram",
+      used_pct: 56.9,
+    });
+    expect((parsed.memory as { used_pct: number }).used_pct).not.toBe(
+      (parsed.system_cpu as { user_pct: number }).user_pct
+    );
+
+    const top = parsed.top_processes as Array<{ command: string; percent_cpu: number }>;
+    expect(top[0].command).toBe("pan_task");
+    expect(top[0].percent_cpu).toBe(100);
+    expect(top.slice(0, 5).every((item) => item.percent_cpu >= 90)).toBe(true);
+    expect(parsed.observed_logical_cpus).toBe(8);
+    expect((parsed.presentation_rules as string[]).join(" ")).toContain("memory.used_pct is RAM");
+
+    const summary = parsed.labeled_summary as Record<string, unknown>;
+    expect(summary["CPU - User"]).toBe("65.1%");
+    expect(summary["Overall CPU Utilization"]).toContain("67.1%");
+    expect(summary["Memory - Used"]).toContain("56.9%");
+    expect(summary["Memory - Used"]).toContain("2858.9 MiB");
+    const topCpu = summary.top_cpu_processes as Array<{ command: string }>;
+    expect(topCpu[0].command).toBe("pan_task");
+  });
+
+  it("keeps an excerpt when parse fails", () => {
+    const parsed = parseSystemResources("not a top dump");
+    expect(parsed.parse_ok).toBe(false);
+    expect(parsed.parse_error).toBeTruthy();
+  });
+});

--- a/tests/schemas/panos.test.ts
+++ b/tests/schemas/panos.test.ts
@@ -105,7 +105,13 @@ describe("firewallName", () => {
     expect(firewallName.safeParse(v).success).toBe(true);
   });
 
-  it.each(["", "a".repeat(64), 42, null])("rejects %j", (v) => {
+  it.each(["", null])("treats empty/null as unset for LocalMCP", (v) => {
+    const parsed = firewallName.safeParse(v);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toBeUndefined();
+  });
+
+  it.each(["a".repeat(64), 42])("rejects %j", (v) => {
     expect(firewallName.safeParse(v).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add LocalMCP HTTP/SSE transport (`/mcp/sse`, `/health`) and Docker image for NCP container deployment
- Seed firewall credentials from NCP env vars; harden `firewall` schema (empty/null → unset)
- Add NetOps enhancements: labeled system resources, log time-window queries, license normalization, and wrapper tools (`get_interface_counters`, `get_rule_hit_counts`, `get_environmentals`, `get_ntp_and_clock`)

## Scope
LocalMCP server + custom tools only. Does **not** include:
- `ncp-sdk-agent/` (agent changes — separate infra work)
- `ncp-api` / `ONES-APPS` / `deploy-ones` integration (follow-up PRs)

## Test plan
- [ ] `npm test` passes
- [ ] `docker build` succeeds with `community-dev` tag
- [ ] LocalMCP health check: `GET /health` returns 200
- [ ] SSE endpoint reachable at `/mcp/sse`
- [ ] Tools return grounded data against lab firewall (system resources, logs, licenses, inventory)


Made with [Cursor](https://cursor.com)